### PR TITLE
feat: add Codex skill evaluation workflow

### DIFF
--- a/.github/workflows/codex-eval.yml
+++ b/.github/workflows/codex-eval.yml
@@ -1,6 +1,8 @@
 name: Skill Evaluation
 
 on:
+  schedule:
+    - cron: '0 16 * * *'
   workflow_dispatch:
     inputs:
       suite_ids:

--- a/.github/workflows/codex-eval.yml
+++ b/.github/workflows/codex-eval.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
     paths:
       - "skills/**/*.md"
+      - ".github/workflows/**"
 
 env:
   TARGET_ID: agora
@@ -207,11 +208,40 @@ jobs:
         uses: actions/github-script@v7
         env:
           REPORT_PATH: ${{ steps.artifacts.outputs.run_dir }}/report.md
+          RUN_DIR: ${{ steps.artifacts.outputs.run_dir }}
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            const path = require('path');
+            let report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+
+            const runDir = process.env.RUN_DIR;
+            const artifactsDir = path.join(runDir, 'case-artifacts');
+            if (fs.existsSync(artifactsDir)) {
+              const cases = fs.readdirSync(artifactsDir);
+              const screenshots = [];
+              for (const caseId of cases) {
+                const caseDir = path.join(artifactsDir, caseId);
+                if (!fs.statSync(caseDir).isDirectory()) continue;
+                for (const file of fs.readdirSync(caseDir)) {
+                  if (file.endsWith('.png') || file.endsWith('.jpg')) {
+                    const filePath = path.join(caseDir, file);
+                    const data = fs.readFileSync(filePath, { encoding: 'base64' });
+                    const ext = path.extname(file).slice(1);
+                    screenshots.push({ caseId, file, data, ext });
+                  }
+                }
+              }
+              if (screenshots.length > 0) {
+                report += '\n\n## Screenshots\n\n';
+                for (const s of screenshots) {
+                  report += `### ${s.caseId} / ${s.file}\n\n`;
+                  report += `<img src="data:image/${s.ext};base64,${s.data}" width="800" />\n\n`;
+                }
+              }
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/codex-eval.yml
+++ b/.github/workflows/codex-eval.yml
@@ -208,45 +208,19 @@ jobs:
         uses: actions/github-script@v7
         env:
           REPORT_PATH: ${{ steps.artifacts.outputs.run_dir }}/report.md
-          RUN_DIR: ${{ steps.artifacts.outputs.run_dir }}
+          ARTIFACT_NAME: eval-run-${{ env.TARGET_ID }}-${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
-            const path = require('path');
-            let report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
-
-            const runDir = process.env.RUN_DIR;
-            const artifactsDir = path.join(runDir, 'case-artifacts');
-            if (fs.existsSync(artifactsDir)) {
-              const cases = fs.readdirSync(artifactsDir);
-              const screenshots = [];
-              for (const caseId of cases) {
-                const caseDir = path.join(artifactsDir, caseId);
-                if (!fs.statSync(caseDir).isDirectory()) continue;
-                for (const file of fs.readdirSync(caseDir)) {
-                  if (file.endsWith('.png') || file.endsWith('.jpg')) {
-                    const filePath = path.join(caseDir, file);
-                    const data = fs.readFileSync(filePath, { encoding: 'base64' });
-                    const ext = path.extname(file).slice(1);
-                    screenshots.push({ caseId, file, data, ext });
-                  }
-                }
-              }
-              if (screenshots.length > 0) {
-                report += '\n\n## Screenshots\n\n';
-                for (const s of screenshots) {
-                  report += `### ${s.caseId} / ${s.file}\n\n`;
-                  report += `<img src="data:image/${s.ext};base64,${s.data}" width="800" />\n\n`;
-                }
-              }
-            }
-
+            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            const artifactLink = `[📦 Download artifacts (screenshots included)](${process.env.RUN_URL})`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `## Skill Eval Report\n\n${report}`,
+              body: `## Skill Eval Report\n\n${report}\n\n---\n${artifactLink}`,
             });
 
       - name: Report results

--- a/.github/workflows/codex-eval.yml
+++ b/.github/workflows/codex-eval.yml
@@ -1,0 +1,234 @@
+name: Skill Evaluation
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite_ids:
+        description: "Comma-separated suite IDs, or 'all' for defaults"
+        required: false
+        default: "all"
+      case_id:
+        description: "Single case ID (leave empty for full suite)"
+        required: false
+        default: ""
+      model:
+        description: "Model for Codex"
+        required: false
+        default: ""
+
+  pull_request:
+    paths:
+      - "skills/**/*.md"
+
+env:
+  TARGET_ID: agora
+  EVAL_REPO: Jiayi-Ye02/agentic-evals
+  EVAL_REF: main
+
+jobs:
+  evaluate:
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v5
+        with:
+          path: skills-repo
+
+      - name: Clone agentic-evals
+        run: |
+          git clone --depth 1 "https://github.com/${EVAL_REPO}.git" agentic-evals
+
+      - name: Copy skill into agentic-evals
+        run: |
+          rm -rf agentic-evals/.agents/skills/agora
+          mkdir -p agentic-evals/.agents/skills/agora
+          cp -r skills-repo/skills/agora/* agentic-evals/.agents/skills/agora/
+          echo "Skill copied from skills-repo into agentic-evals/.agents/skills/agora/"
+
+      - name: Validate YAML
+        working-directory: agentic-evals
+        run: |
+          ruby -e '
+            require "yaml"
+            tid = "agora"
+            Dir["targets/#{tid}/cases/*/suite.yaml"].sort.each { |f| YAML.load_file(f) }
+            Dir["targets/#{tid}/cases/**/*.yaml"].sort.reject { |f| f.end_with?("suite.yaml") }.each { |f| YAML.load_file(f) }
+            YAML.load_file("targets/#{tid}/target.yaml")
+            puts "yaml-ok"
+          '
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        run: |
+          pip install pyyaml
+          npm install -g agent-browser
+
+      - name: Write credentials file
+        env:
+          AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
+          AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
+        run: |
+          cat > /tmp/agora-credentials.env << EOF
+          AGORA_APP_ID=${AGORA_APP_ID}
+          AGORA_APP_CERTIFICATE=${AGORA_APP_CERTIFICATE}
+          EOF
+          chmod 600 /tmp/agora-credentials.env
+
+      - name: Build evaluator prompt
+        env:
+          SUITE_IDS: ${{ github.event.inputs.suite_ids || 'all' }}
+          CASE_ID: ${{ github.event.inputs.case_id || '' }}
+          IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+        run: |
+          EFFECTIVE_CASE_ID="${CASE_ID}"
+          EFFECTIVE_SUITE_IDS="${SUITE_IDS}"
+          if [ "$IS_PR" = "true" ] && [ -z "$EFFECTIVE_CASE_ID" ]; then
+            EFFECTIVE_CASE_ID="convoai-e2e-first-success"
+            EFFECTIVE_SUITE_IDS="workflow"
+          fi
+
+          EVAL_DIR="$(pwd)/agentic-evals"
+
+          cat > /tmp/eval-prompt.txt << 'HEREDOC'
+          You are the skill-eval evaluator agent.
+
+          Instructions:
+          1. Read AGENT.md (canonical repo contract).
+          2. Read .agents/skills/skills-evaluation/SKILL.md (operational instructions).
+          3. Read docs/session-evidence.md (evidence contract).
+          4. Follow the SKILL.md workflow exactly.
+
+          Key rules:
+          - Use spawn_agent with fork_context: false for each case.
+          - Do NOT use codex exec as a substitute for per-case execution.
+          - Create isolated workspaces via the helper script:
+            bash .agents/skills/skills-evaluation/scripts/create_case_workspace.sh
+          - Collect evidence from ~/.codex/sessions/ after each sub-agent completes.
+          - Write all artifacts under runs/<run_id>/.
+
+          Timing requirements:
+          - Record wall-clock timestamps (ISO 8601 UTC) for each case.
+          - Track two phases separately:
+            - "Task execution": from agent receiving the prompt to delivering its final answer.
+            - "Verification": from evidence collection start to all artifacts written.
+          - In report.md, include a "## Timing" section with a human-readable table:
+            | case_id | task_execution | verification | total |
+            Use human-friendly durations like "3m 12s" instead of raw seconds.
+          - In each case-results/<case_id>.json, include timestamps and durations for both phases.
+
+          Report quality requirements:
+          - For each failed assertion, explain WHAT went wrong with specifics (quote actual commands/output).
+          - For each passed assertion, include a one-line evidence summary.
+          - "Suggested Next Fixes" must include concrete actions, not just file paths.
+          - If evaluator browser verification was skipped or degraded, note it but do not fail the case.
+          HEREDOC
+
+          echo "" >> /tmp/eval-prompt.txt
+          echo "Agora credentials file: /tmp/agora-credentials.env" >> /tmp/eval-prompt.txt
+          echo "Before spawning each sub-agent, source this file so AGORA_APP_ID and AGORA_APP_CERTIFICATE are exported." >> /tmp/eval-prompt.txt
+          echo "Do NOT echo or log the credential values." >> /tmp/eval-prompt.txt
+          echo "" >> /tmp/eval-prompt.txt
+          echo "Run parameters:" >> /tmp/eval-prompt.txt
+          echo "- test repo path: ${EVAL_DIR}" >> /tmp/eval-prompt.txt
+          echo "- target_id: ${TARGET_ID}" >> /tmp/eval-prompt.txt
+          echo "- run_mode: single-run" >> /tmp/eval-prompt.txt
+
+          if [ "$EFFECTIVE_SUITE_IDS" != "all" ]; then
+            echo "- suite_ids: ${EFFECTIVE_SUITE_IDS}" >> /tmp/eval-prompt.txt
+          else
+            echo "- suite_ids: use target defaults" >> /tmp/eval-prompt.txt
+          fi
+
+          if [ -n "$EFFECTIVE_CASE_ID" ]; then
+            echo "- case_id: ${EFFECTIVE_CASE_ID}" >> /tmp/eval-prompt.txt
+          fi
+
+          echo "" >> /tmp/eval-prompt.txt
+          echo "Begin the evaluation now." >> /tmp/eval-prompt.txt
+
+      - name: Run Codex evaluator
+        id: run_codex
+        uses: openai/codex-action@v1
+        env:
+          AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
+          AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          responses-api-endpoint: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          prompt-file: /tmp/eval-prompt.txt
+          working-directory: agentic-evals
+          sandbox: danger-full-access
+          model: ${{ github.event.inputs.model || '' }}
+
+      - name: Locate run artifacts
+        id: artifacts
+        run: |
+          LATEST_RUN=$(ls -td agentic-evals/runs/*/ 2>/dev/null | head -1)
+          if [ -z "$LATEST_RUN" ]; then
+            echo "::warning::No run directory found"
+            echo "run_found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "run_dir=${LATEST_RUN}" >> "$GITHUB_OUTPUT"
+          echo "run_found=true" >> "$GITHUB_OUTPUT"
+          [ -f "${LATEST_RUN}/report.md" ] \
+            && echo "report_exists=true" >> "$GITHUB_OUTPUT" \
+            || echo "report_exists=false" >> "$GITHUB_OUTPUT"
+
+      - name: Upload run artifacts
+        if: steps.artifacts.outputs.run_found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-run-${{ env.TARGET_ID }}-${{ github.run_id }}
+          path: ${{ steps.artifacts.outputs.run_dir }}
+          retention-days: 30
+
+      - name: Post report to job summary
+        if: steps.artifacts.outputs.report_exists == 'true'
+        run: |
+          echo "## Skill Eval Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat "${{ steps.artifacts.outputs.run_dir }}/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post report as PR comment
+        if: >
+          github.event_name == 'pull_request' &&
+          steps.artifacts.outputs.report_exists == 'true'
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: ${{ steps.artifacts.outputs.run_dir }}/report.md
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `## Skill Eval Report\n\n${report}`,
+            });
+
+      - name: Report results
+        if: steps.artifacts.outputs.run_found == 'true'
+        run: |
+          RUN_DIR="${{ steps.artifacts.outputs.run_dir }}"
+          RESULTS_DIR="${RUN_DIR}/case-results"
+          [ -d "$RESULTS_DIR" ] || { echo "::warning::No case-results"; exit 0; }
+          FAIL=$(grep -rl '"status": "fail"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
+          PASS=$(grep -rl '"status": "pass"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
+          BLOCKED=$(grep -rl '"status": "blocked"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
+          echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
+          if [ "$FAIL" -gt 0 ]; then
+            echo "::warning::${FAIL} case(s) failed — see report for details"
+          fi

--- a/.github/workflows/gemini-eval.yml
+++ b/.github/workflows/gemini-eval.yml
@@ -1,0 +1,174 @@
+name: Skill Evaluation (Gemini CLI)
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite_ids:
+        description: "Comma-separated suite IDs, or 'all' for defaults"
+        required: false
+        default: "all"
+      case_id:
+        description: "Single case ID (leave empty for full suite)"
+        required: false
+        default: ""
+      model:
+        description: "Gemini model"
+        required: false
+        default: ""
+
+  pull_request:
+    paths:
+      - "skills/**/*.md"
+      - ".github/workflows/**"
+
+env:
+  TARGET_ID: agora
+  EVAL_REPO: Jiayi-Ye02/agentic-evals
+  EVAL_REF: main
+
+jobs:
+  evaluate:
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v5
+        with:
+          path: skills-repo
+
+      - name: Clone agentic-evals
+        run: git clone --depth 1 "https://github.com/${EVAL_REPO}.git" agentic-evals
+
+      - name: Copy skill into agentic-evals
+        run: |
+          rm -rf agentic-evals/.agents/skills/agora
+          mkdir -p agentic-evals/.agents/skills/agora
+          cp -r skills-repo/skills/agora/* agentic-evals/.agents/skills/agora/
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install pyyaml
+          npm install -g agent-browser @google/gemini-cli
+
+      - name: Write credentials
+        env:
+          AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
+          AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
+        run: |
+          printf 'export AGORA_APP_ID="%s"\nexport AGORA_APP_CERTIFICATE="%s"\n' \
+            "$AGORA_APP_ID" "$AGORA_APP_CERTIFICATE" > /tmp/agora-credentials.env
+          chmod 600 /tmp/agora-credentials.env
+
+      - name: Resolve cases
+        id: resolve
+        working-directory: agentic-evals
+        env:
+          SUITE_IDS: ${{ github.event.inputs.suite_ids || 'all' }}
+          CASE_ID: ${{ github.event.inputs.case_id || '' }}
+          IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+        run: |
+          python3 - << 'PY'
+          import yaml, json, os, datetime
+          target_id = os.environ["TARGET_ID"]
+          suite_ids = os.environ.get("SUITE_IDS", "all")
+          case_id = os.environ.get("CASE_ID", "")
+          is_pr = os.environ.get("IS_PR", "false")
+          if is_pr == "true" and not case_id:
+              case_id = "convoai-e2e-first-success"
+              suite_ids = "workflow"
+          target = yaml.safe_load(open(f"targets/{target_id}/target.yaml"))
+          if suite_ids == "all":
+              suite_ids = target["default_suites"]
+          else:
+              suite_ids = [s.strip() for s in suite_ids.split(",")]
+          cases = []
+          for sid in suite_ids:
+              suite = yaml.safe_load(open(f"targets/{target_id}/cases/{sid}/suite.yaml"))
+              for cp in suite["cases"]:
+                  c = yaml.safe_load(open(cp))
+                  if case_id and c["case_id"] != case_id:
+                      continue
+                  cases.append({"case_id": c["case_id"], "path": cp, "user_prompt": c["input"]["user_prompt"]})
+          now = datetime.datetime.now(datetime.timezone.utc)
+          run_id = f"gemini-{now.strftime('%Y%m%dT%H%M%SZ')}"
+          run_dir = f"runs/{run_id}"
+          os.makedirs(f"{run_dir}/case-artifacts", exist_ok=True)
+          os.makedirs(f"{run_dir}/case-results", exist_ok=True)
+          manifest = {"run_mode": "single-run", "run_id": run_id, "runtime": "gemini-cli",
+                      "target_id": target_id, "suite_ids": suite_ids,
+                      "case_ids": [c["case_id"] for c in cases],
+                      "started_at": now.isoformat(), "evidence_mode": "gemini-cli-two-phase"}
+          json.dump(manifest, open(f"{run_dir}/manifest.json", "w"), indent=2)
+          json.dump(cases, open("/tmp/gemini-eval-cases.json", "w"))
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"run_dir={run_dir}\n")
+          print(f"Resolved {len(cases)} cases -> {run_dir}")
+          PY
+
+      - name: Run two-phase evaluation
+        working-directory: agentic-evals
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
+          AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
+          RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
+          GEMINI_MODEL: ${{ github.event.inputs.model || '' }}
+        run: |
+          source /tmp/agora-credentials.env
+          python3 scripts/run_gemini_eval.py
+
+      - name: Generate report
+        if: always()
+        working-directory: agentic-evals
+        env:
+          RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
+        run: python3 scripts/generate_report.py
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-run-gemini-${{ env.TARGET_ID }}-${{ github.run_id }}
+          path: agentic-evals/${{ steps.resolve.outputs.run_dir }}
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Post report to job summary
+        if: always()
+        env:
+          RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
+        run: |
+          if [ -f "${RUN_DIR}/report.md" ]; then
+            echo "## Skill Eval Report (Gemini CLI)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat "${RUN_DIR}/report.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        env:
+          RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const rp = `${process.env.RUN_DIR}/report.md`;
+            if (!fs.existsSync(rp)) return;
+            const report = fs.readFileSync(rp, 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `## Skill Eval Report (Gemini CLI)\n\n${report}\n\n---\n[Download artifacts](${process.env.RUN_URL})`,
+            });

--- a/.github/workflows/gemini-eval.yml
+++ b/.github/workflows/gemini-eval.yml
@@ -118,6 +118,7 @@ jobs:
         working-directory: agentic-evals
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GEMINI_BASE_URL: ${{ secrets.GOOGLE_GEMINI_BASE_URL }}
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}

--- a/.github/workflows/gemini-eval.yml
+++ b/.github/workflows/gemini-eval.yml
@@ -1,6 +1,8 @@
 name: Skill Evaluation (Gemini CLI)
 
 on:
+  schedule:
+    - cron: '0 16 * * *'
   workflow_dispatch:
     inputs:
       suite_ids:

--- a/.github/workflows/skill-judge.yml
+++ b/.github/workflows/skill-judge.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths:
       - "skills/**/*.md"
+      - ".github/workflows/**"
 
 env:
   EVAL_REPO: Jiayi-Ye02/agentic-evals

--- a/.github/workflows/skill-judge.yml
+++ b/.github/workflows/skill-judge.yml
@@ -1,6 +1,8 @@
 name: Skill Quality Review
 
 on:
+  schedule:
+    - cron: '0 16 * * *'
   workflow_dispatch:
     inputs:
       skill_path:

--- a/.github/workflows/skill-judge.yml
+++ b/.github/workflows/skill-judge.yml
@@ -1,0 +1,115 @@
+name: Skill Quality Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      skill_path:
+        description: "Path to skill to evaluate (relative to skills-repo)"
+        required: false
+        default: "skills/agora"
+
+  pull_request:
+    paths:
+      - "skills/**/*.md"
+
+env:
+  EVAL_REPO: Jiayi-Ye02/agentic-evals
+
+jobs:
+  judge:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v5
+        with:
+          path: skills-repo
+
+      - name: Clone agentic-evals
+        run: git clone --depth 1 "https://github.com/${EVAL_REPO}.git" agentic-evals
+
+      - name: Copy skill into agentic-evals
+        run: |
+          rm -rf agentic-evals/.agents/skills/agora
+          mkdir -p agentic-evals/.agents/skills/agora
+          cp -r skills-repo/skills/agora/* agentic-evals/.agents/skills/agora/
+
+      - name: Build judge prompt
+        env:
+          SKILL_PATH: ${{ github.event.inputs.skill_path || 'skills/agora' }}
+        run: |
+          # Map skills-repo path to agentic-evals path
+          EVAL_SKILL_PATH="agentic-evals/.agents/skills/agora"
+
+          SKILL_FILES=$(find "$EVAL_SKILL_PATH" -name "SKILL.md" -type f | sort)
+          FILE_COUNT=$(echo "$SKILL_FILES" | grep -c . || echo 0)
+
+          cat > /tmp/judge-prompt.txt << HEREDOC
+          You have the skill-judge skill loaded. Use it now.
+
+          Evaluate ALL SKILL.md files under ${EVAL_SKILL_PATH}. There are ${FILE_COUNT} SKILL.md files.
+
+          For each SKILL.md:
+          1. Read the file completely.
+          2. Follow the skill-judge evaluation protocol (all 8 dimensions).
+          3. Generate the full structured report.
+
+          After evaluating each file, write a combined report to skill-judge-report.md with:
+          - Summary table of all skills with scores and grades.
+          - Individual evaluation reports.
+          - "Cross-Skill Observations" section.
+          - "Priority Improvements" with top 5 highest-impact changes.
+
+          Files to evaluate:
+          $(echo "$SKILL_FILES" | while read f; do echo "- $f"; done)
+
+          Write the report to skill-judge-report.md in the current directory.
+          HEREDOC
+
+      - name: Run Codex judge
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          responses-api-endpoint: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          prompt-file: /tmp/judge-prompt.txt
+          sandbox: danger-full-access
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-judge-report-${{ github.run_id }}
+          path: skill-judge-report.md
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Post report to job summary
+        if: always()
+        run: |
+          if [ -f skill-judge-report.md ]; then
+            echo "## Skill Quality Review" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat skill-judge-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('skill-judge-report.md')) return;
+            const report = fs.readFileSync('skill-judge-report.md', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `## Skill Quality Review\n\n${report}\n\n---\n[View run](${process.env.RUN_URL})`,
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.4.0]
 
 ### Added
 
+- Codex skill evaluation workflow (`codex-eval.yml`)
+- Gemini CLI skill evaluation workflow (`gemini-eval.yml`)
+- Skill quality review workflow (`skill-judge.yml`)
 - ConvoAI quickstart gating regression cases in `tests/eval-cases.md` — working-baseline detection, no `/join` bypass, and quickstart-skip coverage
 - ConvoAI vendor-default coverage in `tests/eval-cases.md` — Python SDK-backed first-success provider combo and default-parameter checks
 

--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -3,12 +3,12 @@ name: agora
 description: Write code using Agora SDKs (agora.io) for real-time communication. Covers RTC (video/voice, live streaming, screen sharing), RTM/signaling, Conversational AI voice agents, Cloud Recording, Server Gateway, and token generation. Use for Agora, RTC, RTM, video calling, voice calling, screen sharing, recording, tokens, signaling, or ConvoAI requests across Web, React, Next.js, iOS, Android, Go, and Python. Triggers include agora-rtc-sdk-ng, agora-rtc-react, agora-rtm, agora-agent-server-sdk, AgoraVoiceAI, AgoraClient, useConversationalAI, useTranscript, useAgentState, Cloud Recording, Server Gateway, and Agora authentication.
 metadata:
   author: agora
-  version: '1.3.0'
+  version: '1.4.0'
 ---
 
 # Agora (agora.io)
 
-Skill version: 1.3.0
+Skill version: 1.4.0
 
 Build real-time communication applications using Agora SDKs across Web, iOS, Android, and server-side platforms.
 


### PR DESCRIPTION
- Clones agentic-evals framework, copies local skill into it, runs eval
- PR triggers default to e2e case (convoai-e2e-first-success)
- Manual dispatch supports all suites or specific case
- Reports posted to job summary and PR comments

## What does this PR do?

<!-- Brief description of the change -->

## Checklist

- [ ] Freeze-forever test applied to all new inline content — would it still be
  correct if never updated?
- [ ] Routing still correct from `agora/skills/agora/SKILL.md`
- [ ] New or changed local links are valid
- [ ] No duplicate skill names
- [ ] No absolute local paths (`/Users/...`)
- [ ] No hardcoded credentials or API keys
- [ ] At least one eval case added or updated in `tests/eval-cases.md`
  (required for new product/platform additions)
- [ ] If adding code generation guidance: testing guidance updated
- [ ] `scripts/validate-skills.sh` passes locally
