### PR TITLE
feat: add Agora CLI skill references and eval coverage

### DIFF
--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: agora
-description: Write code using Agora SDKs (agora.io) for real-time communication. Covers RTC (video/voice, live streaming, screen sharing), RTM/signaling, Conversational AI voice agents, Cloud Recording, Server Gateway, and token generation. Use for Agora, RTC, RTM, video calling, voice calling, screen sharing, recording, tokens, signaling, or ConvoAI requests across Web, React, Next.js, iOS, Android, Go, and Python. Triggers include agora-rtc-sdk-ng, agora-rtc-react, agora-rtm, agora-agent-server-sdk, AgoraVoiceAI, AgoraClient, useConversationalAI, useTranscript, useAgentState, Cloud Recording, Server Gateway, and Agora authentication.
+description: Write code and integration guidance using Agora products. Covers RTC (video/voice, live streaming, screen sharing), RTM/signaling, Conversational AI voice agents, Agora CLI project workflows, Cloud Recording, Server Gateway, and token generation. Use for Agora, RTC, RTM, ConvoAI, `agora` CLI, `agora login`, `agora project create`, `agora project doctor`, video calling, voice calling, screen sharing, recording, tokens, signaling, or ConvoAI requests across Web, React, Next.js, iOS, Android, Go, and Python.
 metadata:
   author: agora
-  version: '1.4.0'
+  version: '1.5.0'
 ---
 
 # Agora (agora.io)
 
-Skill version: 1.4.0
+Skill version: 1.5.0
 
 Build real-time communication applications using Agora SDKs across Web, iOS, Android, and server-side platforms.
 
@@ -41,6 +41,12 @@ Text messaging, signaling, presence, and metadata. Independent from RTC — chan
 REST API-driven voice AI agents. Create agents that join RTC channels and converse with users via speech. Front-end clients connect via RTC+RTM.
 
 **[references/conversational-ai/README.md](references/conversational-ai/README.md)** — Start here for new projects (quickstart repos to clone), REST API, agent config, recipe repos (agent-samples, agent-toolkit, agent-client-toolkit-react, agent-ui-kit, server-custom-llm, server-mcp)
+
+### Agora CLI
+
+Agora project and auth workflow through the installed `agora` command-line tool. Use when the request is about installing the CLI, logging in, creating or selecting projects, enabling `convoai`, or checking readiness with `project doctor`.
+
+**[references/cli/README.md](references/cli/README.md)** — Start here for `agoraio-cli`, `agora login`, `agora project create`, `agora project feature enable`, `agora project doctor`, config defaults, and script-safe `--json` usage
 
 ### Cloud Recording
 
@@ -85,6 +91,8 @@ Examples of clear requests:
 - "What providers does ConvoAI support?" → `references/conversational-ai/README.md`
 - "I want MLLM with Gemini" → `references/conversational-ai/README.md`
 - "I already have an Agent ID from Agora Studio" → `references/conversational-ai/README.md`
+- "How do I install agoraio-cli?" → `references/cli/README.md`
+- "Help me use agora project doctor" → `references/cli/README.md`
 - "Generate RTC token in Go" → `references/server/tokens.md`
 
 **Vague or multi-product request:** Route through `intake/SKILL.md`.

--- a/skills/agora/references/cli/README.md
+++ b/skills/agora/references/cli/README.md
@@ -1,0 +1,52 @@
+# Agora CLI
+
+Use this module when the user is asking how to use the installed `agora` command-line tool.
+
+Verified against Agora CLI `0.1.1` on 2026-04-14. Write guidance for `>=0.1.1`, but label version-sensitive behavior explicitly when it was only verified in `0.1.1`.
+
+## What the CLI Covers
+
+- OAuth login and local session management
+- Local CLI defaults and config inspection
+- Agora project creation, selection, and inspection
+- Feature enablement for `rtc`, `rtm`, and `convoai`
+- ConvoAI readiness checks through `agora project doctor`
+
+## Routing
+
+| User's request | Read this file next |
+|---|---|
+| Install, login, config directory, `whoami`, `auth status` | [install-auth.md](install-auth.md) |
+| `project create`, `project list`, `project use`, `project show`, `project feature ...` | [projects.md](projects.md) |
+| `project doctor`, readiness, blocking issues, next remediation command | [doctor.md](doctor.md) |
+| Scripted usage, machine-readable output, config persistence, `AGORA_HOME` | [automation.md](automation.md) |
+
+## Quick Reference
+
+| Item | Value |
+|---|---|
+| npm package | `agoraio-cli` |
+| Installed command | `agora` |
+| Deprecated package | `agora-cli-preview` |
+| Minimum skill-supported version | `0.1.1` |
+| Default output mode | `pretty` |
+| Agent-safe output mode | `--json` |
+
+## Current Command Surface
+
+Verified in CLI `0.1.1`:
+
+- top level: `login`, `logout`, `whoami`, `auth`, `config`, `project`
+- auth group: `auth login`, `auth logout`, `auth status`
+- config group: `config path`, `config get`, `config update`
+- project group: `project create`, `project list`, `project use`, `project show`, `project feature`, `project doctor`
+- feature group: `project feature list`, `project feature status`, `project feature enable`
+
+If the user asks for a command outside this surface, do not invent it. Route them to the closest real command or say it is not part of the verified CLI.
+
+## Important Rules
+
+- For agents and scripts, prefer `--json` instead of parsing pretty output.
+- Treat `project doctor` as a readiness checker, not a full Conversational AI onboarding flow.
+- Do not present `agora-cli-preview` as current.
+- Do not call undocumented commands such as `agora convoai init`.

--- a/skills/agora/references/cli/automation.md
+++ b/skills/agora/references/cli/automation.md
@@ -1,0 +1,74 @@
+# Agora CLI Automation and Machine-Readable Use
+
+Verified against Agora CLI `0.1.1`.
+
+## Rule for Agents
+
+If an agent or script needs to consume CLI output, prefer:
+
+```bash
+agora ... --json
+```
+
+Do not tell agents to parse pretty output unless the user explicitly wants human-readable terminal text.
+
+## Output Modes
+
+Verified in `0.1.1`:
+
+- default output mode: `pretty`
+- one-shot override: `--json`
+- persistent default: `agora config update --output json`
+
+Useful commands:
+
+```bash
+agora config path
+agora config get
+agora config update --output json
+```
+
+## Persisted Defaults
+
+The example config for `0.1.1` includes these persisted defaults:
+
+- `output`
+- `apiBaseUrl`
+- `oauthBaseUrl`
+- `oauthClientId`
+- `oauthScope`
+- `telemetryEnabled`
+- `browserAutoOpen`
+- `logLevel`
+- `verbose`
+
+## Local Isolation
+
+For local testing, isolated automation, or CI-style runs, use:
+
+```bash
+AGORA_HOME=/custom/path
+```
+
+This moves the CLI's local state away from the default config directory.
+
+## Suggested Agent Pattern
+
+Use this order:
+
+```bash
+agora login
+agora project use <project>
+agora project doctor --json
+```
+
+If the agent needs to inspect defaults first:
+
+```bash
+agora config get --json
+```
+
+## Things Not to Promise
+
+- Do not claim pretty output is a stable API.
+- Do not claim hidden env vars beyond the documented config directory override and public config commands unless you have verified them for the user's version.

--- a/skills/agora/references/cli/doctor.md
+++ b/skills/agora/references/cli/doctor.md
@@ -1,0 +1,77 @@
+# Agora CLI Doctor
+
+Verified against Agora CLI `0.1.1`.
+
+## Purpose
+
+`agora project doctor` checks whether a project is ready for Conversational AI development from the CLI's point of view.
+
+It verifies:
+
+- logged-in session
+- project resolution or current-project context
+- feature readiness
+- basic project configuration such as App ID presence
+
+It does not replace the full Conversational AI quickstart or end-to-end runtime validation.
+
+## Commands
+
+```bash
+agora project doctor [project]
+agora project doctor --json
+agora project doctor --deep
+```
+
+## Interpreting Results
+
+Verified result states in `0.1.1`:
+
+- `healthy`: project is ready from the CLI's current checks
+- `warning`: partially ready, but not fully clean
+- `not_ready`: blocking issues were found
+- `auth_error`: not logged in or project context cannot be resolved
+
+Exit behavior verified in `0.1.1`:
+
+- healthy doctor run exits `0`
+- blocking readiness issues exit nonzero
+- unauthenticated deep-mode doctor exits `3`
+
+## Common Recovery Commands
+
+If doctor reports an auth problem:
+
+```bash
+agora login
+```
+
+If doctor cannot resolve the target project:
+
+```bash
+agora project use <project>
+```
+
+If doctor reports ConvoAI feature readiness issues:
+
+```bash
+agora project feature enable convoai
+```
+
+## Deep Mode
+
+`--deep` is part of the verified CLI surface in `0.1.1`, but runtime preflight is not currently available there.
+
+Verified `0.1.1` behavior:
+
+- doctor still runs
+- the runtime-preflight item is reported as skipped
+- the message is effectively "Deep runtime preflight is not available in CLI 0.1.1"
+
+Do not promise deeper runtime checks unless you have verified a newer CLI version.
+
+## Fix Mode
+
+`--fix` exists in the command help for `0.1.1`, but do not claim broad automatic remediation behavior unless you have verified it for the user's version.
+
+For safe guidance, prefer explicit remediation commands over "the CLI will fix this automatically."

--- a/skills/agora/references/cli/install-auth.md
+++ b/skills/agora/references/cli/install-auth.md
@@ -1,0 +1,63 @@
+# Agora CLI Install and Auth
+
+Verified against Agora CLI `0.1.1`.
+
+## Install
+
+```bash
+npm install -g agoraio-cli
+```
+
+The installed command is:
+
+```bash
+agora --help
+```
+
+If the user still has the deprecated preview package:
+
+```bash
+npm uninstall -g agora-cli-preview
+npm install -g agoraio-cli
+```
+
+## Login Flow
+
+Primary commands:
+
+```bash
+agora login
+agora whoami
+agora logout
+```
+
+Equivalent auth-group commands:
+
+```bash
+agora auth login
+agora auth status
+agora auth logout
+```
+
+`agora login` starts an OAuth browser flow and stores a local session.
+
+If browser auto-open fails, the CLI prints a URL and the user can open it manually.
+
+## Config and Session Location
+
+The CLI stores config, session, logs, and current-project context under the Agora CLI config directory.
+
+- macOS default: `~/.agora-cli`
+- Linux default: `$XDG_CONFIG_HOME/agora-cli` or `~/.config/agora-cli`
+- local override for testing or isolation: `AGORA_HOME=/custom/path`
+
+## What to Tell the User
+
+- If they are not logged in, tell them to run `agora login` first.
+- If they ask "am I logged in?", use `agora whoami` or `agora auth status`.
+- If they want a noninteractive or isolated local setup, route to [automation.md](automation.md).
+
+## Things Not to Overstate
+
+- Do not promise headless service-account auth; the verified flow in `0.1.1` is browser-based OAuth.
+- Do not claim the preview package is still the recommended install target.

--- a/skills/agora/references/cli/projects.md
+++ b/skills/agora/references/cli/projects.md
@@ -1,0 +1,91 @@
+# Agora CLI Projects
+
+Verified against Agora CLI `0.1.1`.
+
+## Core Workflow
+
+Use this sequence for most CLI project tasks:
+
+```bash
+agora login
+agora project create my-agent-demo --feature rtc --feature convoai
+agora project use my-agent-demo
+agora project show
+agora project feature list
+```
+
+## Project Commands
+
+### Create
+
+```bash
+agora project create <name> [--region global|cn] [--type general|voice-agent|chat|rtc] [--template voice-agent] [--feature rtc|rtm|convoai]
+```
+
+For agent guidance, prefer explicit `--feature` flags because they match the later `project feature` workflow.
+
+### List
+
+```bash
+agora project list [--page N] [--page-size N] [--keyword <text>]
+```
+
+Use this when the user needs to discover a project ID or exact project name.
+
+### Select Current Project
+
+```bash
+agora project use <project>
+```
+
+`<project>` can be a project ID or exact project name.
+
+After `project use`, commands like `project show`, `project feature list`, and `project doctor` can run without repeating the project argument.
+
+### Show One Project
+
+```bash
+agora project show [project]
+```
+
+This is the quickest way to inspect App ID, region, sign key, and token-enabled status for the current project.
+
+## Feature Commands
+
+Valid verified feature names in `0.1.1`:
+
+- `rtc`
+- `rtm`
+- `convoai`
+
+Commands:
+
+```bash
+agora project feature list [project]
+agora project feature status <feature> [project]
+agora project feature enable <feature> [project]
+```
+
+Most ConvoAI onboarding preparation starts with:
+
+```bash
+agora project feature enable convoai
+```
+
+## Current-Project Context
+
+If the user omits `[project]`, the CLI uses the locally selected project context.
+
+If no project is selected, the verified recovery is:
+
+```bash
+agora project use <project>
+```
+
+or rerun the command with a project argument.
+
+## Things Not to Hallucinate
+
+- Do not invent `agora project delete`.
+- Do not invent `agora project feature disable`.
+- Do not invent ConvoAI-specific nested groups under `agora project`.

--- a/tests/eval-cases.md
+++ b/tests/eval-cases.md
@@ -372,6 +372,94 @@ For each case:
 
 ---
 
+## 5. CLI Skill Coverage (CLI-series)
+
+### CLI-01: Root routing for install and login
+
+- User Input: "How do I install agoraio-cli and log in?"
+- Expected Behavior: Routes to the top-level CLI module rather than RTC / ConvoAI / intake
+- Pass Criteria: Uses the CLI references, installs `agoraio-cli`, names the `agora` command, and includes `agora login`
+- Result: ___
+
+### CLI-02: Deprecated preview package migration
+
+- User Input: "I still have agora-cli-preview installed. What should I do?"
+- Expected Behavior: Explains the stable package migration path
+- Pass Criteria: Tells the user to uninstall `agora-cli-preview` and install `agoraio-cli`; does not present the preview package as current
+- Result: ___
+
+### CLI-03: Version-aware minimum support
+
+- User Input: "What CLI version should I use for this skill?"
+- Expected Behavior: Anchors guidance on the verified minimum version
+- Pass Criteria: States that the skill is verified against CLI `0.1.1` and written for `>=0.1.1`; does not hand-wave with "latest"
+- Result: ___
+
+### CLI-04: Project creation guidance stays within real command surface
+
+- User Input: "Create an Agora project for RTC and ConvoAI with the CLI"
+- Expected Behavior: Uses the documented project workflow
+- Pass Criteria: References `agora project create <name> --feature rtc --feature convoai`; does not invent unsupported flags or subcommands
+- Result: ___
+
+### CLI-05: Feature enable guidance uses real feature values
+
+- User Input: "How do I enable ConvoAI in the CLI?"
+- Expected Behavior: Uses the project feature subcommands
+- Pass Criteria: Uses `agora project feature enable convoai`; only references valid features `rtc`, `rtm`, or `convoai`
+- Result: ___
+
+### CLI-06: Doctor guidance includes actual recovery commands
+
+- User Input: "agora project doctor says my project is not ready. What next?"
+- Expected Behavior: Uses the CLI doctor workflow and suggested remediations
+- Pass Criteria: Mentions `agora login`, `agora project use <project>`, or `agora project feature enable convoai` where applicable; does not invent automatic healing behavior
+- Result: ___
+
+### CLI-07: Doctor deep mode is version-aware
+
+- User Input: "What does `agora project doctor --deep` do?"
+- Expected Behavior: Describes the currently verified behavior instead of promising future runtime checks
+- Pass Criteria: States that deep mode exists, but in CLI `0.1.1` runtime preflight is not available and is reported as skipped
+- Result: ___
+
+### CLI-08: Agent automation prefers JSON output
+
+- User Input: "I want an agent to call the CLI safely from scripts"
+- Expected Behavior: Recommends machine-readable output and stable parsing boundaries
+- Pass Criteria: Recommends `--json` or persisted JSON output mode; does not tell agents to parse pretty output by default
+- Result: ___
+
+### CLI-09: Config defaults and override locations are accurate
+
+- User Input: "Where does the Agora CLI keep its config, and can I override it?"
+- Expected Behavior: Explains the config directory and override mechanism
+- Pass Criteria: References the default Agora CLI config directory and `AGORA_HOME`; does not invent unrelated env vars
+- Result: ___
+
+### CLI-10: Failure path does not hallucinate missing commands
+
+- User Input: "Can I run `agora convoai init`?"
+- Expected Behavior: Rejects the invented command and routes to the real command set
+- Pass Criteria: Explicitly says this is not part of the verified CLI surface; redirects to actual `auth`, `config`, `project`, `project feature`, or `project doctor` commands
+- Result: ___
+
+### CLI-11: Root routing bypasses intake for clear CLI requests
+
+- User Input: "Help me use `agora project doctor`"
+- Expected Behavior: Routes directly to the CLI module
+- Pass Criteria: Does not go through `agora-intake`; treats the request as a CLI usage question first
+- Result: ___
+
+### CLI-12: ConvoAI onboarding prep points to CLI doctor without pretending onboarding is complete
+
+- User Input: "Before I integrate Conversational AI, what can the CLI verify for me?"
+- Expected Behavior: Positions the CLI as a readiness tool, not as the whole ConvoAI workflow
+- Pass Criteria: Mentions login, project selection, feature status, and `project doctor`; does not claim the CLI alone completes end-to-end ConvoAI onboarding
+- Result: ___
+
+---
+
 ## Evaluation Log
 
 | Date | Skill Version | Pass | Fail | Failed Cases | Fix Actions |


### PR DESCRIPTION
## Summary

  - add a dedicated Agora CLI module under `skills/agora/references/cli`
  - extend the root Agora skill routing so install/login/project/doctor requests go to the CLI references directly
  - document the verified CLI 0.1.1 command surface for:
    - install and auth
    - project creation and selection
    - feature enablement
    - `project doctor`
    - automation and `--json` usage
  - add CLI eval cases covering routing, deprecated package migration, version-aware guidance, real command usage, doctor remediation, and agent-safe automation patterns

  ## Why

  The Agora skill already covered RTC, RTM, ConvoAI, server tokens, and Cloud Recording, but CLI workflows were still implicit. This PR makes CLI guidance explicit, version-aware, and harder to hallucinate.

  ## Validation

  - `bash scripts/validate-skills.sh`
  - `npm view agoraio-cli version versions --json`
  - `npx -y agoraio-cli@0.1.1 --help`
  - `npx -y agoraio-cli@0.1.1 auth --help`
  - `npx -y agoraio-cli@0.1.1 project --help`
  - `npx -y agoraio-cli@0.1.1 project create --help`
  - `npx -y agoraio-cli@0.1.1 project feature --help`
  - `npx -y agoraio-cli@0.1.1 project doctor --help`

  ## Notes

  - guidance is anchored to CLI `0.1.1` and written for `>=0.1.1`
  - undocumented commands are intentionally excluded to reduce hallucinated recommendations

## Checklist

- [ ] Freeze-forever test applied to all new inline content — would it still be
  correct if never updated?
- [ ] Routing still correct from `agora/skills/agora/SKILL.md`
- [ ] New or changed local links are valid
- [ ] No duplicate skill names
- [ ] No absolute local paths (`/Users/...`)
- [ ] No hardcoded credentials or API keys
- [ ] At least one eval case added or updated in `tests/eval-cases.md`
  (required for new product/platform additions)
- [ ] If adding code generation guidance: testing guidance updated
- [ ] `scripts/validate-skills.sh` passes locally
