### PR TITLE
feat: add hard gate constraints to ConvoAI quickstart and routing

### DIFF
--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -88,12 +88,17 @@ Examples of clear requests:
 - "RTC Web video call" → `references/rtc/web.md`
 - "ConvoAI Python" → `references/conversational-ai/README.md`
 - "I want to build a demo that talks to an agent" → `references/conversational-ai/README.md`
+- "I want to build a voice chat demo with an AI agent" → `references/conversational-ai/README.md`
+- "Help me set up a voice AI assistant" → `references/conversational-ai/README.md`
+- "I want a conversational AI voice app" → `references/conversational-ai/README.md`
 - "What providers does ConvoAI support?" → `references/conversational-ai/README.md`
 - "I want MLLM with Gemini" → `references/conversational-ai/README.md`
 - "I already have an Agent ID from Agora Studio" → `references/conversational-ai/README.md`
 - "How do I install agoraio-cli?" → `references/cli/README.md`
 - "Help me use agora project doctor" → `references/cli/README.md`
 - "Generate RTC token in Go" → `references/server/tokens.md`
+
+> **Routing constraint:** When a request matches ConvoAI and the user does not have a proven working baseline, go to `references/conversational-ai/README.md` which will route to `quickstarts.md`. Do NOT go through `intake/SKILL.md` for clear ConvoAI requests. Do NOT skip the quickstart gates by jumping directly into code generation or project scaffolding.
 
 **Vague or multi-product request:** Route through `intake/SKILL.md`.
 Only do this when the product is still genuinely unclear after checking for obvious

--- a/skills/agora/references/conversational-ai/README.md
+++ b/skills/agora/references/conversational-ai/README.md
@@ -2,6 +2,8 @@
 
 REST API-driven voice AI agents. Create agents that join RTC channels and converse with users via speech. Front-end clients connect via RTC+RTM.
 
+> **HARD GATE:** If the user does not have a working ConvoAI baseline, route to [quickstarts.md](quickstarts.md) and stay there. Do not generate code, scaffold projects, propose custom architecture, or write files until the quickstart state machine reaches `complete`. This is not a suggestion — it is a blocking constraint.
+
 ## Routing: Classify the Request
 
 The key question: does the user already have a **working ConvoAI baseline**?

--- a/skills/agora/references/conversational-ai/quickstarts.md
+++ b/skills/agora/references/conversational-ai/quickstarts.md
@@ -1,11 +1,8 @@
 ---
 name: conversational-ai-quickstarts
 description: |
-  Locked quickstart flow for Agora Conversational AI when the user does not yet have a proven
-  working baseline. Use for new projects and integrations where the ConvoAI path has not been
-  proven end to end. Restricts the model to one decision group per turn: baseline path,
-  project readiness, then backend path only if needed. Do not generate code or custom
-  architecture before the quickstart gates are resolved.
+  Locked quickstart flow for Agora Conversational AI. Use when no working baseline exists.
+  BLOCKING: Do not write code, create files, scaffold projects, or propose custom architecture until the quickstart state machine reaches `complete`. Use the Agora CLI directly to verify and fix project readiness — do not ask the user to self-report. One decision group per turn. Before every reply, check: baseline_resolved? cli_readiness_done? vendor_gate_done? If any is false, stay in the current gate.
 license: MIT
 metadata:
   author: agora


### PR DESCRIPTION
- Add blocking constraint in quickstarts.md description: no code/files/scaffold until state machine completes
- Add HARD GATE blockquote at top of ConvoAI README.md
- Add routing constraint and extra English examples in root SKILL.md
- Simplify description to 4 lines with 3-boolean self-check rule

## What does this PR do?

<!-- Brief description of the change -->

## Checklist

- [ ] Freeze-forever test applied to all new inline content — would it still be
  correct if never updated?
- [ ] Routing still correct from `agora/skills/agora/SKILL.md`
- [ ] New or changed local links are valid
- [ ] No duplicate skill names
- [ ] No absolute local paths (`/Users/...`)
- [ ] No hardcoded credentials or API keys
- [ ] At least one eval case added or updated in `tests/eval-cases.md`
  (required for new product/platform additions)
- [ ] If adding code generation guidance: testing guidance updated
- [ ] `scripts/validate-skills.sh` passes locally
