### PR TITLE
fix: default eval workflows to e2e case only, remove pass/fail from F…

### DIFF
--- a/.github/workflows/codex-eval.yml
+++ b/.github/workflows/codex-eval.yml
@@ -6,13 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       suite_ids:
-        description: "Comma-separated suite IDs, or 'all' for defaults"
+        description: "Comma-separated suite IDs, or 'all' for all suites"
         required: false
-        default: "all"
+        default: "workflow"
       case_id:
         description: "Single case ID (leave empty for full suite)"
         required: false
-        default: ""
+        default: "convoai-e2e-first-success"
       model:
         description: "Model for Codex"
         required: false
@@ -89,16 +89,11 @@ jobs:
 
       - name: Build evaluator prompt
         env:
-          SUITE_IDS: ${{ github.event.inputs.suite_ids || 'all' }}
-          CASE_ID: ${{ github.event.inputs.case_id || '' }}
-          IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          SUITE_IDS: ${{ github.event.inputs.suite_ids || 'workflow' }}
+          CASE_ID: ${{ github.event.inputs.case_id || 'convoai-e2e-first-success' }}
         run: |
           EFFECTIVE_CASE_ID="${CASE_ID}"
           EFFECTIVE_SUITE_IDS="${SUITE_IDS}"
-          if [ "$IS_PR" = "true" ] && [ -z "$EFFECTIVE_CASE_ID" ]; then
-            EFFECTIVE_CASE_ID="convoai-e2e-first-success"
-            EFFECTIVE_SUITE_IDS="workflow"
-          fi
 
           EVAL_DIR="$(pwd)/agentic-evals"
 

--- a/.github/workflows/gemini-eval.yml
+++ b/.github/workflows/gemini-eval.yml
@@ -6,13 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       suite_ids:
-        description: "Comma-separated suite IDs, or 'all' for defaults"
+        description: "Comma-separated suite IDs, or 'all' for all suites"
         required: false
-        default: "all"
+        default: "workflow"
       case_id:
         description: "Single case ID (leave empty for full suite)"
         required: false
-        default: ""
+        default: "convoai-e2e-first-success"
       model:
         description: "Gemini model"
         required: false
@@ -74,19 +74,15 @@ jobs:
         id: resolve
         working-directory: agentic-evals
         env:
-          SUITE_IDS: ${{ github.event.inputs.suite_ids || 'all' }}
-          CASE_ID: ${{ github.event.inputs.case_id || '' }}
+          SUITE_IDS: ${{ github.event.inputs.suite_ids || 'workflow' }}
+          CASE_ID: ${{ github.event.inputs.case_id || 'convoai-e2e-first-success' }}
           IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
         run: |
           python3 - << 'PY'
           import yaml, json, os, datetime
           target_id = os.environ["TARGET_ID"]
-          suite_ids = os.environ.get("SUITE_IDS", "all")
-          case_id = os.environ.get("CASE_ID", "")
-          is_pr = os.environ.get("IS_PR", "false")
-          if is_pr == "true" and not case_id:
-              case_id = "convoai-e2e-first-success"
-              suite_ids = "workflow"
+          suite_ids = os.environ.get("SUITE_IDS", "workflow")
+          case_id = os.environ.get("CASE_ID", "convoai-e2e-first-success")
           target = yaml.safe_load(open(f"targets/{target_id}/target.yaml"))
           if suite_ids == "all":
               suite_ids = target["default_suites"]

--- a/.github/workflows/openclaw-eval.yml
+++ b/.github/workflows/openclaw-eval.yml
@@ -6,13 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       suite_ids:
-        description: "Comma-separated suite IDs, or 'all' for defaults"
+        description: "Comma-separated suite IDs, or 'all' for all suites"
         required: false
-        default: "all"
+        default: "workflow"
       case_id:
         description: "Single case ID (leave empty for full suite)"
         required: false
-        default: ""
+        default: "convoai-e2e-first-success"
 
   pull_request:
     paths:

--- a/scripts/notify_feishu.py
+++ b/scripts/notify_feishu.py
@@ -102,11 +102,13 @@ else:
 
     card = {
         "header": {
-            "title": {"tag": "plain_text", "content": f"{status} {WORKFLOW}"},
+            "title": {"tag": "plain_text", "content": WORKFLOW},
             "template": "blue"
         },
         "elements": []
     }
+    if cases_summary:
+        card["elements"].append({"tag": "markdown", "content": cases_summary})
     if timing:
         card["elements"].append({"tag": "markdown", "content": f"**耗时:** {timing}"})
     card["elements"].append({

--- a/skills/agora/references/cli/projects.md
+++ b/skills/agora/references/cli/projects.md
@@ -8,7 +8,7 @@ Use this sequence for most CLI project tasks:
 
 ```bash
 agora login
-agora project create my-agent-demo --feature rtc --feature convoai
+agora project create my-agent-demo --feature rtc --feature rtm --feature convoai
 agora project use my-agent-demo
 agora project show
 agora project feature list


### PR DESCRIPTION
…eishu title

- Change workflow_dispatch defaults to suite_ids=workflow, case_id=convoai-e2e-first-success
- Remove IS_PR conditional overrides (defaults handle all trigger types now)
- Feishu notification title shows only workflow name, no pass/fail status
- Add --feature rtm to CLI project create example in projects.md

## What does this PR do?

<!-- Brief description of the change -->

## Checklist

- [ ] Freeze-forever test applied to all new inline content — would it still be
  correct if never updated?
- [ ] Routing still correct from `agora/skills/agora/SKILL.md`
- [ ] New or changed local links are valid
- [ ] No duplicate skill names
- [ ] No absolute local paths (`/Users/...`)
- [ ] No hardcoded credentials or API keys
- [ ] At least one eval case added or updated in `tests/eval-cases.md`
  (required for new product/platform additions)
- [ ] If adding code generation guidance: testing guidance updated
- [ ] `scripts/validate-skills.sh` passes locally
