### PR TITLE
feat: hermes eval uses evaluator+subagent pattern

### DIFF
--- a/.github/workflows/hermes-eval.yml
+++ b/.github/workflows/hermes-eval.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install runtime dependencies
         run: |
           pip install pyyaml
-          npm install -g agent-browser @openai/codex
+          npm install -g agent-browser
 
       - name: Install Hermes Agent
         run: |
@@ -156,10 +156,10 @@ jobs:
           run_dir = f"runs/{run_id}"
           os.makedirs(f"{run_dir}/case-artifacts", exist_ok=True)
           os.makedirs(f"{run_dir}/case-results", exist_ok=True)
-          manifest = {"run_mode": "single-run", "run_id": run_id, "runtime": "hermes-agent",
+          manifest = {"run_mode": "single-run", "run_id": run_id, "runtime": "hermes-single-phase",
                       "target_id": target_id, "suite_ids": suite_ids,
                       "case_ids": [c["case_id"] for c in cases],
-                      "started_at": now.isoformat(), "evidence_mode": "hermes-two-phase"}
+                      "started_at": now.isoformat(), "evidence_mode": "hermes-single-phase"}
           json.dump(manifest, open(f"{run_dir}/manifest.json", "w"), indent=2)
           json.dump(cases, open("/tmp/hermes-eval-cases.json", "w"))
           with open(os.environ["GITHUB_OUTPUT"], "a") as out:
@@ -167,7 +167,7 @@ jobs:
           print(f"Resolved {len(cases)} cases -> {run_dir}")
           PY
 
-      - name: Run two-phase evaluation
+      - name: Run evaluator+subagent evaluation
         working-directory: agentic-evals
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -179,7 +179,7 @@ jobs:
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           source /tmp/agora-credentials.env
-          python3 scripts/run_hermes_eval.py
+          python3 scripts/run_hermes_subagent_eval.py
 
       - name: Generate report
         if: always()


### PR DESCRIPTION
- Calls run_hermes_subagent_eval.py instead of run_hermes_eval.py
- Evaluator spawns isolated sub-agent via shell, then verifies independently
- Dropped codex dependency, kept agent-browser
- Manifest uses hermes-single-phase evidence mode

## What does this PR do?

<!-- Brief description of the change -->

## Checklist

- [ ] Freeze-forever test applied to all new inline content — would it still be
  correct if never updated?
- [ ] Routing still correct from `agora/skills/agora/SKILL.md`
- [ ] New or changed local links are valid
- [ ] No duplicate skill names
- [ ] No absolute local paths (`/Users/...`)
- [ ] No hardcoded credentials or API keys
- [ ] At least one eval case added or updated in `tests/eval-cases.md`
  (required for new product/platform additions)
- [ ] If adding code generation guidance: testing guidance updated
- [ ] `scripts/validate-skills.sh` passes locally
