### PR TITLE
Align skill and plugin versions to 1.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "agora",
       "source": "./",
       "description": "Real-time communication with Agora SDKs — RTC, RTM, Conversational AI, and token generation",
-      "version": "1.2.0"
+      "version": "1.5.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agora",
   "description": "Real-time communication with Agora SDKs — RTC, RTM, Conversational AI, and token generation",
-  "version": "1.2.0",
+  "version": "1.5.1",
   "author": {
     "name": "Agora"
   },

--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -11,12 +11,12 @@ description: >-
   first — do not implement from scratch.
 metadata:
   author: agora
-  version: '1.5.0'
+  version: '1.5.1'
 ---
 
 # Agora (agora.io)
 
-Skill version: 1.5.0
+Skill version: 1.5.1
 
 Build real-time communication applications using Agora SDKs across Web, iOS, Android, and server-side platforms.
 


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the change -->

## Checklist

- [ ] Freeze-forever test applied to all new inline content — would it still be
  correct if never updated?
- [ ] Routing still correct from `agora/skills/agora/SKILL.md`
- [ ] New or changed local links are valid
- [ ] No duplicate skill names
- [ ] No absolute local paths (`/Users/...`)
- [ ] No hardcoded credentials or API keys
- [ ] At least one eval case added or updated in `tests/eval-cases.md`
  (required for new product/platform additions)
- [ ] If adding code generation guidance: testing guidance updated
- [ ] `scripts/validate-skills.sh` passes locally
