### PR TITLE
updated workflow

### DIFF
--- a/.github/workflows/sync-anthropics-fork.yml
+++ b/.github/workflows/sync-anthropics-fork.yml
@@ -17,6 +17,10 @@ on:
       - ".github/anthropics-pr-body.md"
   workflow_dispatch:
 
+concurrency:
+  group: sync-voice-ai-integration
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -24,7 +28,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     env:
-      TARGET_REPO: chenyuguo-agora/skills
+      TARGET_REPO: AgoraIO/skills
       TARGET_BRANCH: sync/voice-ai-integration
       TARGET_PATH: skills/voice-ai-integration
 
@@ -50,7 +54,14 @@ jobs:
           SYNC_TOKEN: ${{ secrets.ANTHROPICS_SKILLS_SYNC_TOKEN }}
         run: |
           cd "$RUNNER_TEMP/target-repo"
-          git checkout -B "$TARGET_BRANCH"
+          git fetch origin "$TARGET_BRANCH":"refs/remotes/origin/$TARGET_BRANCH" || true
+
+          if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
+            git checkout -B "$TARGET_BRANCH" "refs/remotes/origin/$TARGET_BRANCH"
+          else
+            git checkout -B "$TARGET_BRANCH"
+          fi
+
           mkdir -p "$(dirname "$TARGET_PATH")"
           rsync -a --delete "$RUNNER_TEMP/export/skills/voice-ai-integration/" "$TARGET_PATH/"
           git config user.name "github-actions[bot]"
@@ -69,4 +80,4 @@ jobs:
       - name: Print upstream PR URL
         run: |
           echo "Open this URL to create or update the upstream PR manually:"
-          echo "https://github.com/anthropics/skills/compare/main...chenyuguo-agora:${TARGET_BRANCH}?expand=1"
+          echo "https://github.com/anthropics/skills/compare/main...AgoraIO:${TARGET_BRANCH}?expand=1"


### PR DESCRIPTION
## Summary

  This updates the Anthropic sync workflow for the generated voice-ai-integration branch.

  The workflow now targets the correct source-owned repo namespace, and it handles the sync branch using the standard bot-managed generated-branch pattern so repeat syncs
  do not fail with stale branch state.

  ## What changed

  - Updated the sync target repo from chenyuguo-agora/skills to AgoraIO/skills
  - Updated the printed compare URL to use AgoraIO as the fork namespace
  - Added workflow concurrency for the sync job to prevent overlapping runs from racing on the same generated branch
  - Changed the branch bootstrap logic to fetch origin/sync/voice-ai-integration before recreating the local branch
  - Kept git push --force-with-lease for safe bot-managed branch replacement

  ## Why this fixes the failure

  The previous workflow cloned only the default branch, then recreated sync/voice-ai-integration locally and pushed it with --force-with-lease without first fetching the
  remote sync branch. If that remote branch had moved, Git rejected the push with stale info.

  The updated flow fetches the remote sync branch first and resets the local branch against it when present, so the lease check has the correct remote baseline.

  ## Why --force-with-lease is still correct

  This branch is generated and bot-owned, not a collaborative branch. Each run rewrites the branch to match the latest exported bundle, so a normal fast-forward push is not
  reliable.

  --force-with-lease is the standard safe choice here because it:

  - allows the bot to replace the generated branch contents
  - still protects against clobbering an unexpected remote update the workflow has not seen

  ## Files changed

  - .github/workflows/sync-anthropics-fork.yml

  ## Validation

  - Reviewed the updated workflow branch-handling logic and target repo settings locally
  - Confirmed the workflow now points at AgoraIO/skills
  - Confirmed the sync branch is fetched before checkout -B
  - Confirmed concurrency is enabled for the generated-branch sync job