### PR TITLE
Release/v1.6.1

### DIFF
--- a/.github/workflows/sync-anthropics-fork.yml
+++ b/.github/workflows/sync-anthropics-fork.yml
@@ -17,6 +17,10 @@ on:
       - ".github/anthropics-pr-body.md"
   workflow_dispatch:
 
+concurrency:
+  group: sync-voice-ai-integration
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -24,7 +28,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     env:
-      TARGET_REPO: chenyuguo-agora/skills
+      TARGET_REPO: AgoraIO/skills
       TARGET_BRANCH: sync/voice-ai-integration
       TARGET_PATH: skills/voice-ai-integration
 
@@ -50,7 +54,14 @@ jobs:
           SYNC_TOKEN: ${{ secrets.ANTHROPICS_SKILLS_SYNC_TOKEN }}
         run: |
           cd "$RUNNER_TEMP/target-repo"
-          git checkout -B "$TARGET_BRANCH"
+          git fetch origin "$TARGET_BRANCH":"refs/remotes/origin/$TARGET_BRANCH" || true
+
+          if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
+            git checkout -B "$TARGET_BRANCH" "refs/remotes/origin/$TARGET_BRANCH"
+          else
+            git checkout -B "$TARGET_BRANCH"
+          fi
+
           mkdir -p "$(dirname "$TARGET_PATH")"
           rsync -a --delete "$RUNNER_TEMP/export/skills/voice-ai-integration/" "$TARGET_PATH/"
           git config user.name "github-actions[bot]"
@@ -69,4 +80,4 @@ jobs:
       - name: Print upstream PR URL
         run: |
           echo "Open this URL to create or update the upstream PR manually:"
-          echo "https://github.com/anthropics/skills/compare/main...chenyuguo-agora:${TARGET_BRANCH}?expand=1"
+          echo "https://github.com/anthropics/skills/compare/main...AgoraIO:${TARGET_BRANCH}?expand=1"

--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ With the Agora skill loaded, the agent can then:
 
 You should not need to manually dig through the Agora Console just to get a first voice agent running.
 
-For local CLI-powered onboarding, install the Agora CLI with:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh | sh -s -- --add-to-path
-```
-
-The npm path, `npm install -g agoraio-cli`, is also supported as an install wrapper for the same Go-based `agora` command when Node.js 18+ is available.
-
 ## Installation
 
 ### Skills CLI
@@ -52,6 +44,14 @@ The npm path, `npm install -g agoraio-cli`, is also supported as an install wrap
 ```bash
 npx skills add github:AgoraIO/skills
 ```
+
+### Agora CLI (for local onboarding)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh | sh
+```
+
+The npm path, `npm install -g agoraio-cli`, is also supported as an install wrapper for the same Go-based `agora` command when Node.js 18+ is available.
 
 ### Claude Code Plugin
 

--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   integrating Agora into an app.
 metadata:
   author: agora
-  version: '1.6.0'
+  version: '1.6.1'
 ---
 
 <!-- applies-from: v0.2.0 -->

--- a/skills/agora/references/cli/env.md
+++ b/skills/agora/references/cli/env.md
@@ -112,6 +112,8 @@ Write rules:
 - `--template nextjs|standard`: override the workspace detector when the credential key layout must be forced
 - do not combine `--append` and `--overwrite`
 
+Ask for explicit approval before running `--overwrite`, and state the target path before writing. Prefer append/update behavior for existing env files.
+
 Do not use template files such as `.env.example`, `.env.sample`, or `.env.template` as write targets for real values or secrets.
 
 In `0.2.0`, `project env write` updates or creates repo-local `.agora/project.json` metadata and records detected `projectType` / `envPath` when missing.

--- a/skills/agora/references/cli/install-auth.md
+++ b/skills/agora/references/cli/install-auth.md
@@ -8,6 +8,8 @@ Verified against Agora CLI `0.2.0`.
 
 ## Install
 
+Run read-only checks first (`agora version`, `which agora`, or equivalent). Ask for user approval before running installers, global package installs, shell-profile updates, or package removal commands.
+
 Preferred macOS / Linux / POSIX shell installer:
 
 ```bash

--- a/skills/agora/references/conversational-ai/quickstarts.md
+++ b/skills/agora/references/conversational-ai/quickstarts.md
@@ -138,7 +138,7 @@ There is one default quickstart path. Do not offer alternatives before first suc
    1.2 Python 3.8+
 2. CLI preflight
    2.1 Log in: `agora login`
-   2.2 Verify CLI version with `agora version` (minimum `0.1.7`)
+   2.2 Verify CLI version with `agora version` (minimum `0.2.0`)
    2.3 Prefer `agora init <name> --template python` for a new official sample checkout
    2.4 For an existing official quickstart, use `agora quickstart env write <repo> --project <project>`
    2.5 If decomposing the flow, prefer the current selected project only if it is directly usable for first-success
@@ -274,14 +274,14 @@ Before we jump into custom code, let's first use the official sample to get the 
 
 ### Environment Check
 
-Before starting the CLI readiness flow, verify that all runtime dependencies are installed. Run these checks and fix any missing tools automatically. Do not ask the user to install them manually.
+Before starting the CLI readiness flow, verify that all runtime dependencies are installed. Auto-install missing tools where safe (`bun`, `agora` CLI), and route the user for system runtime installs (`node`, `python`) when needed.
 
 | Dependency | Check command | Minimum version | Install if missing |
 |-----------|--------------|----------------|-------------------|
 | Node.js | `node --version` | 18+ | Direct the user to https://nodejs.org or use `nvm install 22` |
 | Bun | `bun --version` | 1.0+ | `npm install -g bun` |
 | Python | `python3 --version` | 3.8+ | Direct the user to https://python.org |
-| Agora CLI | `agora version` | 0.1.7+ | `curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh \| sh -s -- --add-to-path` |
+| Agora CLI | `agora version` | 0.2.0+ | `curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh \| sh` |
 
 Execution rules:
 - Check all four in order. If any is missing or below minimum version, install/update it before continuing.

--- a/skills/agora/references/conversational-ai/quickstarts.md
+++ b/skills/agora/references/conversational-ai/quickstarts.md
@@ -2,7 +2,7 @@
 name: conversational-ai-quickstarts
 description: |
   Locked quickstart flow for Agora Conversational AI. Use when no working baseline exists.
-  BLOCKING: Do not write code, create files, scaffold projects, or propose custom architecture until the quickstart state machine reaches `complete`. Use the Agora CLI directly to verify and fix project readiness — do not ask the user to self-report. For mutating commands (install/upgrade tools, change project features, write env files), ask for user confirmation first. One decision group per turn. Before every reply, check: baseline_resolved? cli_readiness_done? vendor_gate_done? If any is false, stay in the current gate.
+  BLOCKING: Do not write code, create files, scaffold projects, or propose custom architecture until the quickstart state machine reaches `complete`. Use the Agora CLI directly to verify and fix project readiness — do not ask the user to self-report. Get scoped setup approval before mutating commands, then continue within that scope. One decision group per turn. Before every reply, check: baseline_resolved? cli_readiness_done? vendor_gate_done? If any is false, stay in the current gate.
   SAMPLE INTEGRITY: After cloning the official sample, the default allowed actions are: install dependencies, populate env with CLI-extracted credentials, and start the app using the commands documented in the sample's README. Do NOT substitute your own startup commands or replace the sample with a self-built implementation. If a documented command is blocked by sandbox or permissions, re-run that exact command with escalation if available; otherwise stop and report an environment constraint. If the failure is localized to the official sample itself, a minimal upstream-shaped workaround is allowed, but not a custom architecture or repo rewrite.
 license: MIT
 metadata:
@@ -62,7 +62,7 @@ Apply this policy for quickstart setup actions:
 
 1. Detect first: run read-only checks and report what is installed.
 2. Recommend second: propose the best baseline path from user preference + detected tools.
-3. Confirm before mutate: ask before any install/upgrade, project feature change, or file write.
+3. Confirm scope before mutate: ask once for bounded quickstart setup approval.
 4. Execute exactly: once confirmed, run the documented command without substituting variants.
 5. Report clearly: summarize what changed and what remains blocked.
 
@@ -71,6 +71,25 @@ Guardrails:
 - Never silently install or upgrade system tools.
 - Never assume language/runtime preference when the user has already stated one.
 - Prefer least-surprise behavior: explicit approval for machine changes, deterministic commands, and transparent outcomes.
+
+Approved quickstart setup scope covers:
+
+- installing or upgrading missing non-system setup tools needed for the selected baseline (`bun`, `pnpm`/`npm`, `agora`)
+- running `agora login`
+- selecting an existing suitable project
+- enabling required Agora features on the selected project
+- writing or updating the selected sample's expected env file
+- installing the selected sample's dependencies
+- starting the selected sample
+
+Ask again before:
+
+- creating a new Agora project
+- deleting files, uninstalling packages, or removing projects
+- overwriting env files with `--overwrite`
+- printing or exposing secrets in chat
+- installing or upgrading system runtimes such as Node.js or Python
+- changing files or settings outside the selected quickstart repo and selected Agora project
 
 ## Command Integrity Under Environment Restrictions
 
@@ -116,7 +135,7 @@ Use three readiness layers during quickstart:
 
 ## CLI-Driven Readiness Check
 
-The project readiness step requires the agent to directly execute Agora CLI commands to verify and fix prerequisites. Do not ask the user to run CLI commands themselves and do not offer manual alternatives. The agent checks directly; for mutating actions (for example enabling features or writing env files), ask for confirmation first.
+The project readiness step requires the agent to directly execute Agora CLI commands to verify and fix prerequisites. Do not ask the user to run CLI commands themselves and do not offer manual alternatives. The agent checks directly; mutating actions may proceed inside the approved quickstart setup scope.
 
 The CLI covers:
 
@@ -129,7 +148,12 @@ The CLI covers:
 - App ID presence, App Certificate presence, and other basic project checks
 - `agora project doctor` readiness checks
 
-Use `agora init` for a new official quickstart when the CLI can perform the clone + project binding + env writing safely. Use `agora quickstart env write` for an existing official quickstart repo and as the default path for seeding env files. Use `agora project env --with-secrets --json` only when direct raw credential values are explicitly needed outside `quickstart env write` (for example manual mapping flows). Use `project show --json` only when project metadata inspection is needed.
+Use the CLI in this order:
+
+1. For a new official quickstart, prefer `agora init` when it can clone, bind the project, and write env safely.
+2. For an existing official quickstart, use `agora quickstart env write` to seed env files.
+3. Use `agora project env --with-secrets --json` only for manual mapping flows that need raw credential values.
+4. Use `project show --json` only for project metadata inspection.
 
 Do **not** treat a healthy doctor result as a proven ConvoAI baseline.
 
@@ -148,7 +172,7 @@ After the CLI readiness step is resolved, return to this quickstart and continue
 Select the baseline sample from user preference first, then installed tools:
 
 - If user explicitly wants Python (or has no preference): use `agent-quickstart-python`.
-- If user explicitly wants Node/TypeScript and has Node 22+ + pnpm 8+: use `agent-quickstart-nextjs`.
+- If user explicitly wants Node/TypeScript and has Node 22+ plus pnpm 8+ (preferred) or npm fallback: use `agent-quickstart-nextjs`.
 - If user asks for Go as the final backend, still complete one official quickstart baseline first, then route to [go-sdk.md](go-sdk.md) for backend implementation.
 
 If no stack preference is provided, default to:
@@ -157,14 +181,14 @@ If no stack preference is provided, default to:
 
 1. Runtime prerequisites
    1.1 Python baseline: Bun (package manager & script runner) + Python 3.8+
-   1.2 Node/TS baseline: Node.js 22+ + pnpm 8+
+   1.2 Node/TS baseline: Node.js 22+ + pnpm 8+ preferred; fallback to npm when pnpm is unavailable and the sample supports npm
 2. CLI preflight
    2.1 Log in: `agora login`
    2.2 Verify CLI version with `agora version` (minimum `0.2.0`)
    2.3 Prefer `agora init <name> --template <template>` where `<template>` matches the selected baseline (`python` or `nextjs`)
    2.4 For an existing official quickstart, use `agora quickstart env write <repo> --project <project>`
    2.5 If decomposing the flow, prefer the current selected project only if it is directly usable for first-success
-   2.6 Otherwise select another directly usable project or create a new dedicated token-ready project
+   2.6 Otherwise select another directly usable project, or ask before creating a new dedicated token-ready project
    2.7 Ensure `rtc`, `rtm`, and `convoai` are enabled for the first-success path
    2.8 Use `agora project env --with-secrets --json` only when direct raw credential values are explicitly needed outside `init` / `quickstart env write`
    2.9 Check `agora project doctor`
@@ -173,7 +197,7 @@ If no stack preference is provided, default to:
    3.1 Clone the selected official quickstart (`agent-quickstart-python` or `agent-quickstart-nextjs`) directly or through `agora init`
    3.2 Install and start with the selected sample's documented commands:
       - Python baseline: `bun install` then `bun run dev`
-      - Node/TS baseline: `pnpm install` then `pnpm dev`
+      - Node/TS baseline: run `pnpm install` then `pnpm dev` when pnpm is available; otherwise fall back to `npm install` then `npm run dev` when the sample supports npm
    3.3 Ensure the expected env file is present:
       - Python baseline: `server/.env` with `APP_ID` + `APP_CERTIFICATE`
       - Node/TS baseline: `.env.local` with `NEXT_PUBLIC_AGORA_APP_ID` + `NEXT_AGORA_APP_CERTIFICATE`
@@ -238,7 +262,7 @@ If the user is no longer sample-aligned and needs provider-specific config layou
 
 ## Baseline Path
 
-Default baseline is `agent-quickstart-python` unless the user explicitly chooses Node/TypeScript and the required Node/pnpm runtime is available.
+Default baseline is `agent-quickstart-python` unless the user explicitly chooses Node/TypeScript and the required Node plus package-manager runtime is available.
 
 After first success, the user can explore other demos:
 
@@ -254,9 +278,9 @@ The quickstart is a blocking state machine. While a state is unresolved, the onl
 | State | Allowed | Forbidden | Next prompt | Advance when |
 |---|---|---|---|---|
 | `intro` | Give a short plain-language intro to what ConvoAI is | Code, repo plans, framework recommendations | Product intro text | Intro delivered |
-| `intake` | Confirm preferred stack (`python` or `node/ts`) and get confirmation policy for mutating commands | Code, repo inspection, implementation | Intake prompt | Stack preference + install/update consent are resolved |
+| `intake` | Confirm preferred stack (`python` or `node/ts`) and get scoped quickstart setup approval | Code, repo inspection, implementation | Intake prompt | Stack preference + setup scope are resolved |
 | `environment_check` | Check Node.js, Bun, Python, Agora CLI versions. Recommend and run installs/upgrades only after user confirmation. | Code, repo inspection, implementation | Environment check commands | Required dependencies for selected baseline are installed and meet minimum versions |
-| `project_readiness` | Execute CLI commands directly to verify auth, project, App ID, App Certificate, feature activation, and fix missing prerequisites; ask before mutating project state. Extract credentials from CLI env output. | Code, repo inspection, implementation | Readiness prompt | Control-plane readiness confirmed and credentials captured |
+| `project_readiness` | Execute CLI commands directly to verify auth, project, App ID, App Certificate, feature activation, and fix missing prerequisites inside the approved setup scope. Extract credentials from CLI env output. | Code, repo inspection, implementation | Readiness prompt | Control-plane readiness confirmed and credentials captured |
 | `vendor_defaults` | Ask whether to use the defaults (no vendor keys), BYOK, show the current official provider list, choose a non-default cascading / MLLM path, or reuse a Studio Agent ID. **Skip this gate entirely if the user has not mentioned BYOK, providers, or Studio Agent ID — defaults apply automatically.** | Code, implementation | Vendor-defaults prompt | User picks or gate is auto-skipped |
 | `vendor_selection` | Collect only provider-mode and provider choices after checking the official current provider docs | Code, implementation, secret collection | Custom-provider prompt | Provider mode and provider names are resolved |
 | `studio_agent_id` | Collect the Agora Studio Agent ID and confirm the user wants Studio to remain the source of truth for agent config | Code, re-asking provider setup from scratch | Studio-Agent-ID prompt | The Studio Agent ID path is resolved |
@@ -304,37 +328,39 @@ Ask this right after intro when stack preference or install policy is still unkn
 
 ```text
 Before we run setup, which baseline do you want first: Python or Node/TypeScript?
-I can run read-only environment checks automatically. If tools are missing, do you approve a one-time setup scope for install/upgrade and project-mutating commands in this quickstart, or should I stop and ask before each change?
+I can check your environment and handle normal quickstart setup in one approved scope. I will ask again before creating a new Agora project, overwriting files, exposing secrets, installing Node/Python, or changing anything outside this quickstart.
 ```
 
 ### Environment Check
 
-Before starting the CLI readiness flow, verify that all runtime dependencies are installed. Run read-only checks first, then ask before install/upgrade actions.
+Before starting the CLI readiness flow, verify that all runtime dependencies are installed. Run read-only checks first, then use the approved setup scope for non-system quickstart tools.
 
 | Dependency | Check command | Minimum version | Install if missing |
 |-----------|--------------|----------------|-------------------|
 | Node.js (Node/TS baseline) | `node --version` | 22+ | Direct the user to https://nodejs.org or use `nvm install 22` |
-| pnpm (Node/TS baseline) | `pnpm --version` | 8+ | `npm install -g pnpm` |
+| pnpm or npm (Node/TS baseline) | `pnpm --version`, then `npm --version` if needed | pnpm 8+ preferred; npm fallback allowed | Use npm if pnpm is unavailable and the sample supports it |
 | Bun (Python baseline) | `bun --version` | 1.0+ | `npm install -g bun` |
 | Python (Python baseline) | `python3 --version` | 3.8+ | Direct the user to https://python.org |
 | Agora CLI (all baselines) | `agora version` | 0.2.0+ | `curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh \| sh` |
 
 Execution rules:
-- Check required dependencies for the selected baseline plus Agora CLI. If any required dependency is missing or below minimum version, request approval for install/update or stop with explicit next steps.
+- Check only the selected baseline's dependencies plus Agora CLI.
+- Install or update non-system tools only inside the approved setup scope; otherwise stop with clear next steps.
 - For Node.js and Python, if they are not installed, tell the user what to install and wait — do not attempt to install system-level runtimes.
-- For Bun, ask first, then install via npm if the user approves.
-- For Agora CLI, ask first, then install with the official curl installer if the user approves. `npm install -g agoraio-cli` is acceptable when Node 18+ is available and the package is acting as the Go binary install wrapper.
+- For Python baseline, install Bun only when covered by the approved setup scope.
+- For Node/TS baseline, use pnpm if available; otherwise use npm if the sample supports it. Do not install pnpm just because it is preferred.
+- For Agora CLI, install with the official curl installer only when covered by the approved setup scope. `npm install -g agoraio-cli` is acceptable when Node 18+ is available and the package is acting as the Go binary install wrapper.
 - If Agora CLI is installed but outdated, use `agora upgrade --check` for package-manager-specific guidance or reinstall from the official installer.
 - Only proceed to project readiness after all required checks for the selected baseline pass.
 
 ### Project Readiness
 
-Do not ask the user to self-report readiness or choose between manual and CLI paths. The agent must directly execute CLI commands to check each prerequisite. For any mutating remediation command, ask for confirmation before executing it.
+Check readiness directly with the Agora CLI. Do not ask the user to self-report it. Mutating fixes may run inside the approved setup scope; ask again for out-of-scope actions.
 
 Tell the user what you are about to check, then execute the commands yourself:
 
 ```text
-Let me check your project readiness — I'll use the Agora CLI to verify login, project, App ID, App Certificate, and ConvoAI activation. I'll run read-only checks first, then ask before any command that changes project state or writes files. Once the control-plane checks out, I'll seed the official quickstart env file.
+I will check Agora login, project, App ID, App Certificate, and ConvoAI activation with the CLI. Read-only checks come first; setup fixes stay inside the approved scope.
 ```
 
 #### Agent execution sequence
@@ -354,20 +380,20 @@ Run these commands in order. Use `--json` where available so you can parse the o
    - If the user explicitly named a project, inspect that exact project first and try to repair it with documented CLI commands.
    - If the user did **not** name a project and the current selected project is not directly usable, inspect existing projects and look for a directly usable candidate.
    - If a directly usable candidate is found, select it and explicitly tell the user which project was chosen before continuing.
-   - If no directly usable candidate exists, create a new dedicated first-success project with the required features already enabled, then select it.
+   - If no directly usable candidate exists, ask before creating a new dedicated first-success project with the required features already enabled.
 
 4. **Credential export / env write** — use `agora quickstart env write` as the default for official quickstarts.
    - If this fully seeds the sample env file, do not run `agora project env --with-secrets`.
    - Use `agora project env --with-secrets --json` only when direct raw values are explicitly needed for manual mapping.
    - If `--with-secrets` is used, do not echo secret values in chat output.
-   - If `--with-secrets` fails because the project is still not token-ready, treat that as a project-readiness failure and keep fixing or replace the project according to the selection rules above.
+   - If `--with-secrets` fails because the project is still not token-ready, treat that as a project-readiness failure; repair within the approved setup scope or ask before replacing the project.
 
 5. **Doctor** — `agora project doctor --json`
    - If `healthy` or `warning` → control-plane readiness is confirmed, not runtime/sample readiness.
-   - If `not_ready` → read the reported issues and fix them directly:
-     - ConvoAI not enabled → `agora project feature enable convoai`, then re-run doctor.
+   - If `not_ready` → read the reported issues and remediate within the approved setup scope:
+     - ConvoAI not enabled → run `agora project feature enable convoai`, then re-run doctor.
      - RTM or related service just enabled → allow bounded wait/retry for up to about 5 minutes before concluding the project still needs intervention.
-     - Other issues → run the matching recovery command (see [doctor.md](../cli/doctor.md)), then re-run doctor.
+     - Other issues → run the matching in-scope recovery command (see [doctor.md](../cli/doctor.md)), then re-run doctor. Ask before out-of-scope recovery.
    - Repeat until doctor passes at the control-plane layer.
 
 6. **Auto-populate env** — once control-plane readiness passes, seed the official quickstart env with `agora quickstart env write` when possible.
@@ -459,7 +485,7 @@ C. Re-check the latest official docs to verify whether that provider is supporte
 
 ## Output: Structured Quickstart Spec
 
-After all gates are resolved, normalize the result into a short spec and continue automatically.
+After all gates are resolved, normalize the result into a short spec and continue within the approved setup scope. Ask before any unapproved mutating action.
 
 ```yaml
 use_case: [text]
@@ -507,7 +533,7 @@ These are available after the first success baseline is proven. Do not use these
 
 **Repo:** <https://github.com/AgoraIO-Conversational-AI/agent-quickstart-nextjs>
 
-Single Next.js app with built-in API routes for token generation and agent lifecycle. Includes React UI with live transcription. Requires Node.js 22+ and pnpm 8+. See the repo README for setup.
+Single Next.js app with built-in API routes for token generation and agent lifecycle. Includes React UI with live transcription. Requires Node.js 22+ and a supported package manager; prefer pnpm 8+ and fall back to npm when pnpm is unavailable and the sample supports npm. See the repo README for setup.
 
 ### Decomposed Samples (`agent-samples`)
 

--- a/skills/agora/references/conversational-ai/quickstarts.md
+++ b/skills/agora/references/conversational-ai/quickstarts.md
@@ -129,7 +129,7 @@ The CLI covers:
 - App ID presence, App Certificate presence, and other basic project checks
 - `agora project doctor` readiness checks
 
-Use `agora init` for a new official quickstart when the CLI can perform the clone + project binding + env writing safely. Use `agora quickstart env write` for an existing official quickstart repo. Use `agora project env --with-secrets --json` as the primary source of truth when the flow is decomposed and the agent needs App ID/App Certificate values directly. Use `project show --json` only when project metadata inspection is needed.
+Use `agora init` for a new official quickstart when the CLI can perform the clone + project binding + env writing safely. Use `agora quickstart env write` for an existing official quickstart repo and as the default path for seeding env files. Use `agora project env --with-secrets --json` only when direct raw credential values are explicitly needed outside `quickstart env write` (for example manual mapping flows). Use `project show --json` only when project metadata inspection is needed.
 
 Do **not** treat a healthy doctor result as a proven ConvoAI baseline.
 
@@ -156,32 +156,35 @@ If no stack preference is provided, default to:
 - **Repo:** <https://github.com/AgoraIO-Conversational-AI/agent-quickstart-python> *(Python server + React frontend)*
 
 1. Runtime prerequisites
-   1.1 Bun (package manager & script runner)
-   1.2 Python 3.8+
+   1.1 Python baseline: Bun (package manager & script runner) + Python 3.8+
+   1.2 Node/TS baseline: Node.js 22+ + pnpm 8+
 2. CLI preflight
    2.1 Log in: `agora login`
    2.2 Verify CLI version with `agora version` (minimum `0.2.0`)
-   2.3 Prefer `agora init <name> --template python` for a new official sample checkout
+   2.3 Prefer `agora init <name> --template <template>` where `<template>` matches the selected baseline (`python` or `nextjs`)
    2.4 For an existing official quickstart, use `agora quickstart env write <repo> --project <project>`
    2.5 If decomposing the flow, prefer the current selected project only if it is directly usable for first-success
    2.6 Otherwise select another directly usable project or create a new dedicated token-ready project
    2.7 Ensure `rtc`, `rtm`, and `convoai` are enabled for the first-success path
-   2.8 Export App ID + App Certificate with `agora project env --with-secrets --json` only when direct credential values are needed outside `init` / `quickstart env write`
+   2.8 Use `agora project env --with-secrets --json` only when direct raw credential values are explicitly needed outside `init` / `quickstart env write`
    2.9 Check `agora project doctor`
    2.10 If RTM was just enabled, allow bounded wait/retry before concluding runtime failure
 3. Official sample baseline
    3.1 Clone the selected official quickstart (`agent-quickstart-python` or `agent-quickstart-nextjs`) directly or through `agora init`
-   3.2 Run `bun install`
-   3.3 Ensure `server/.env` exists and contains `APP_ID` and `APP_CERTIFICATE` (`agora quickstart env write` can seed this for the official quickstart)
+   3.2 Install and start with the selected sample's documented commands:
+      - Python baseline: `bun install` then `bun run dev`
+      - Node/TS baseline: `pnpm install` then `pnpm dev`
+   3.3 Ensure the expected env file is present:
+      - Python baseline: `server/.env` with `APP_ID` + `APP_CERTIFICATE`
+      - Node/TS baseline: `.env.local` with `NEXT_PUBLIC_AGORA_APP_ID` + `NEXT_AGORA_APP_CERTIFICATE`
+      (`agora quickstart env write` is the default seeding path)
    3.4 Do not rename the sample's env variables during first success
-   3.5 Start with `bun run dev` (auto-creates venv, installs deps, starts both services)
 4. Success gate
-   4.1 Frontend loads at http://localhost:3000
-   4.2 Backend runs at http://localhost:8000
-   4.3 The user can start a conversation
-   4.4 The agent joins the RTC channel
-   4.5 The user can speak to the agent and hear TTS back
-   4.6 Only after this counts as a working baseline
+   4.1 App loads at the sample's documented local URL
+   4.2 User can start a conversation from the UI
+   4.3 Agent joins the RTC channel
+   4.4 User can speak to the agent and hear TTS back
+   4.5 Only after this counts as a working baseline
 
 ## First-Success Vendor Defaults
 
@@ -301,7 +304,7 @@ Ask this right after intro when stack preference or install policy is still unkn
 
 ```text
 Before we run setup, which baseline do you want first: Python or Node/TypeScript?
-I can run environment checks automatically. If anything is missing, do you want me to install/upgrade tools for you when possible, or should I stop and ask first?
+I can run read-only environment checks automatically. If tools are missing, do you approve a one-time setup scope for install/upgrade and project-mutating commands in this quickstart, or should I stop and ask before each change?
 ```
 
 ### Environment Check
@@ -310,18 +313,19 @@ Before starting the CLI readiness flow, verify that all runtime dependencies are
 
 | Dependency | Check command | Minimum version | Install if missing |
 |-----------|--------------|----------------|-------------------|
-| Node.js | `node --version` | 18+ | Direct the user to https://nodejs.org or use `nvm install 22` |
-| Bun | `bun --version` | 1.0+ | `npm install -g bun` |
-| Python | `python3 --version` | 3.8+ | Direct the user to https://python.org |
-| Agora CLI | `agora version` | 0.2.0+ | `curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh \| sh` |
+| Node.js (Node/TS baseline) | `node --version` | 22+ | Direct the user to https://nodejs.org or use `nvm install 22` |
+| pnpm (Node/TS baseline) | `pnpm --version` | 8+ | `npm install -g pnpm` |
+| Bun (Python baseline) | `bun --version` | 1.0+ | `npm install -g bun` |
+| Python (Python baseline) | `python3 --version` | 3.8+ | Direct the user to https://python.org |
+| Agora CLI (all baselines) | `agora version` | 0.2.0+ | `curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh \| sh` |
 
 Execution rules:
-- Check all four in order. If any is missing or below minimum version, request approval for install/update or stop with explicit next steps.
+- Check required dependencies for the selected baseline plus Agora CLI. If any required dependency is missing or below minimum version, request approval for install/update or stop with explicit next steps.
 - For Node.js and Python, if they are not installed, tell the user what to install and wait — do not attempt to install system-level runtimes.
 - For Bun, ask first, then install via npm if the user approves.
 - For Agora CLI, ask first, then install with the official curl installer if the user approves. `npm install -g agoraio-cli` is acceptable when Node 18+ is available and the package is acting as the Go binary install wrapper.
 - If Agora CLI is installed but outdated, use `agora upgrade --check` for package-manager-specific guidance or reinstall from the official installer.
-- Only proceed to project readiness after all four checks pass.
+- Only proceed to project readiness after all required checks for the selected baseline pass.
 
 ### Project Readiness
 
@@ -352,9 +356,10 @@ Run these commands in order. Use `--json` where available so you can parse the o
    - If a directly usable candidate is found, select it and explicitly tell the user which project was chosen before continuing.
    - If no directly usable candidate exists, create a new dedicated first-success project with the required features already enabled, then select it.
 
-4. **Credential export / env write** — use `agora quickstart env write` for an official quickstart, or `agora project env --with-secrets --json` when direct credential values are needed.
-   - Extract App ID and App Certificate from the CLI env output, not from Agora Console.
-   - Keep these values for later sample env population.
+4. **Credential export / env write** — use `agora quickstart env write` as the default for official quickstarts.
+   - If this fully seeds the sample env file, do not run `agora project env --with-secrets`.
+   - Use `agora project env --with-secrets --json` only when direct raw values are explicitly needed for manual mapping.
+   - If `--with-secrets` is used, do not echo secret values in chat output.
    - If `--with-secrets` fails because the project is still not token-ready, treat that as a project-readiness failure and keep fixing or replace the project according to the selection rules above.
 
 5. **Doctor** — `agora project doctor --json`
@@ -365,7 +370,10 @@ Run these commands in order. Use `--json` where available so you can parse the o
      - Other issues → run the matching recovery command (see [doctor.md](../cli/doctor.md)), then re-run doctor.
    - Repeat until doctor passes at the control-plane layer.
 
-6. **Auto-populate env** — once control-plane readiness passes, seed the official quickstart env with `agora quickstart env write` when possible. For the Python quickstart, the target is `server/.env` with `APP_ID` and `APP_CERTIFICATE`. No manual copy-paste needed.
+6. **Auto-populate env** — once control-plane readiness passes, seed the official quickstart env with `agora quickstart env write` when possible.
+   - Python quickstart target: `server/.env` with `APP_ID` and `APP_CERTIFICATE`.
+   - Node/TS quickstart target: `.env.local` with `NEXT_PUBLIC_AGORA_APP_ID` and `NEXT_AGORA_APP_CERTIFICATE`.
+   No manual copy-paste needed when template-aware write succeeds.
 
 7. **Sample-ready gate**
    - Install dependencies and start the official sample using the documented commands.

--- a/skills/agora/references/conversational-ai/quickstarts.md
+++ b/skills/agora/references/conversational-ai/quickstarts.md
@@ -2,7 +2,7 @@
 name: conversational-ai-quickstarts
 description: |
   Locked quickstart flow for Agora Conversational AI. Use when no working baseline exists.
-  BLOCKING: Do not write code, create files, scaffold projects, or propose custom architecture until the quickstart state machine reaches `complete`. Use the Agora CLI directly to verify and fix project readiness — do not ask the user to self-report. One decision group per turn. Before every reply, check: baseline_resolved? cli_readiness_done? vendor_gate_done? If any is false, stay in the current gate.
+  BLOCKING: Do not write code, create files, scaffold projects, or propose custom architecture until the quickstart state machine reaches `complete`. Use the Agora CLI directly to verify and fix project readiness — do not ask the user to self-report. For mutating commands (install/upgrade tools, change project features, write env files), ask for user confirmation first. One decision group per turn. Before every reply, check: baseline_resolved? cli_readiness_done? vendor_gate_done? If any is false, stay in the current gate.
   SAMPLE INTEGRITY: After cloning the official sample, the default allowed actions are: install dependencies, populate env with CLI-extracted credentials, and start the app using the commands documented in the sample's README. Do NOT substitute your own startup commands or replace the sample with a self-built implementation. If a documented command is blocked by sandbox or permissions, re-run that exact command with escalation if available; otherwise stop and report an environment constraint. If the failure is localized to the official sample itself, a minimal upstream-shaped workaround is allowed, but not a custom architecture or repo rewrite.
 license: MIT
 metadata:
@@ -32,14 +32,13 @@ If the user already has a working baseline, exit this file and route back throug
 Follow this exact user-visible order:
 
 1. Product intro in plain language
-2. Environment check — verify runtime dependencies are installed
-3. Project-readiness checkpoint — use the CLI directly to verify and fix
-4. Vendor-path confirmation — **skip if the user has not mentioned BYOK, providers, or Studio Agent ID; defaults apply automatically**
-5. Vendor selection, only if the user asks for the current provider list or chooses a non-default path
-6. Studio Agent ID confirmation, only if the user wants to reuse an agent configured in Agora Studio
-7. Structured quickstart spec
-
-There is no baseline-path or backend-path selection. The default path is always the Python server + React frontend quickstart (`agent-quickstart-python`). Do not offer alternatives before first success.
+2. Intake — confirm preferred stack (`python` or `node/ts`) and confirm whether the agent is allowed to install/upgrade missing tools
+3. Environment check — verify runtime dependencies are installed
+4. Project-readiness checkpoint — use the CLI directly to verify and fix
+5. Vendor-path confirmation — **skip if the user has not mentioned BYOK, providers, or Studio Agent ID; defaults apply automatically**
+6. Vendor selection, only if the user asks for the current provider list or chooses a non-default path
+7. Studio Agent ID confirmation, only if the user wants to reuse an agent configured in Agora Studio
+8. Structured quickstart spec
 
 ## Interaction Rules
 
@@ -54,7 +53,24 @@ There is no baseline-path or backend-path selection. The default path is always 
 - Unless the user explicitly asks for BYOK (bring your own key) or a different provider stack, anchor on the defaults first — no vendor API keys needed.
 - For non-default provider selection, fetch the official current provider docs before confirming support or generating config details.
 - If the user already has an **Agora Studio Agent ID** from `https://console.agora.io/studio/agents`, treat that as a separate quickstart branch. Do not re-ask STT/LLM/TTS provider choices unless the user explicitly wants to replace the Studio-managed config.
-- Do not offer baseline-path choices. The default is always `agent-quickstart-python` (Python server + React frontend). Other demos are referenced only after first success.
+- If stack preference is unknown, ask one short intake question before selecting the baseline sample.
+- If stack preference is still unspecified after intake, default to `agent-quickstart-python`.
+
+## Industry-Standard Execution Policy
+
+Apply this policy for quickstart setup actions:
+
+1. Detect first: run read-only checks and report what is installed.
+2. Recommend second: propose the best baseline path from user preference + detected tools.
+3. Confirm before mutate: ask before any install/upgrade, project feature change, or file write.
+4. Execute exactly: once confirmed, run the documented command without substituting variants.
+5. Report clearly: summarize what changed and what remains blocked.
+
+Guardrails:
+
+- Never silently install or upgrade system tools.
+- Never assume language/runtime preference when the user has already stated one.
+- Prefer least-surprise behavior: explicit approval for machine changes, deterministic commands, and transparent outcomes.
 
 ## Command Integrity Under Environment Restrictions
 
@@ -100,7 +116,7 @@ Use three readiness layers during quickstart:
 
 ## CLI-Driven Readiness Check
 
-The project readiness step requires the agent to directly execute Agora CLI commands to verify and fix prerequisites. Do not ask the user to run CLI commands themselves, do not offer manual alternatives, and do not present choices. The agent checks, the agent fixes.
+The project readiness step requires the agent to directly execute Agora CLI commands to verify and fix prerequisites. Do not ask the user to run CLI commands themselves and do not offer manual alternatives. The agent checks directly; for mutating actions (for example enabling features or writing env files), ask for confirmation first.
 
 The CLI covers:
 
@@ -127,11 +143,17 @@ For command details, route to the CLI references:
 
 After the CLI readiness step is resolved, return to this quickstart and continue from the same readiness checkpoint.
 
-## Default Quickstart Path
+## First-Success Baseline Selection
 
-There is one default quickstart path. Do not offer alternatives before first success.
+Select the baseline sample from user preference first, then installed tools:
 
-**Repo:** <https://github.com/AgoraIO-Conversational-AI/agent-quickstart-python> *(Python server + React frontend)*
+- If user explicitly wants Python (or has no preference): use `agent-quickstart-python`.
+- If user explicitly wants Node/TypeScript and has Node 22+ + pnpm 8+: use `agent-quickstart-nextjs`.
+- If user asks for Go as the final backend, still complete one official quickstart baseline first, then route to [go-sdk.md](go-sdk.md) for backend implementation.
+
+If no stack preference is provided, default to:
+
+- **Repo:** <https://github.com/AgoraIO-Conversational-AI/agent-quickstart-python> *(Python server + React frontend)*
 
 1. Runtime prerequisites
    1.1 Bun (package manager & script runner)
@@ -148,7 +170,7 @@ There is one default quickstart path. Do not offer alternatives before first suc
    2.9 Check `agora project doctor`
    2.10 If RTM was just enabled, allow bounded wait/retry before concluding runtime failure
 3. Official sample baseline
-   3.1 Clone `agent-quickstart-python` directly or through `agora init`
+   3.1 Clone the selected official quickstart (`agent-quickstart-python` or `agent-quickstart-nextjs`) directly or through `agora init`
    3.2 Run `bun install`
    3.3 Ensure `server/.env` exists and contains `APP_ID` and `APP_CERTIFICATE` (`agora quickstart env write` can seed this for the official quickstart)
    3.4 Do not rename the sample's env variables during first success
@@ -213,7 +235,7 @@ If the user is no longer sample-aligned and needs provider-specific config layou
 
 ## Baseline Path
 
-The default and only quickstart baseline is `agent-quickstart-python` (Python server + React frontend).
+Default baseline is `agent-quickstart-python` unless the user explicitly chooses Node/TypeScript and the required Node/pnpm runtime is available.
 
 After first success, the user can explore other demos:
 
@@ -229,8 +251,9 @@ The quickstart is a blocking state machine. While a state is unresolved, the onl
 | State | Allowed | Forbidden | Next prompt | Advance when |
 |---|---|---|---|---|
 | `intro` | Give a short plain-language intro to what ConvoAI is | Code, repo plans, framework recommendations | Product intro text | Intro delivered |
-| `environment_check` | Check Node.js, Bun, Python, Agora CLI versions. Install or update missing tools. | Code, repo inspection, implementation | Environment check commands | All four dependencies are installed and meet minimum versions |
-| `project_readiness` | Execute CLI commands directly to verify auth, project, App ID, App Certificate, feature activation, and fix missing prerequisites. Extract credentials from CLI env output. | Code, repo inspection, implementation | Readiness prompt | Control-plane readiness confirmed and credentials captured |
+| `intake` | Confirm preferred stack (`python` or `node/ts`) and get confirmation policy for mutating commands | Code, repo inspection, implementation | Intake prompt | Stack preference + install/update consent are resolved |
+| `environment_check` | Check Node.js, Bun, Python, Agora CLI versions. Recommend and run installs/upgrades only after user confirmation. | Code, repo inspection, implementation | Environment check commands | Required dependencies for selected baseline are installed and meet minimum versions |
+| `project_readiness` | Execute CLI commands directly to verify auth, project, App ID, App Certificate, feature activation, and fix missing prerequisites; ask before mutating project state. Extract credentials from CLI env output. | Code, repo inspection, implementation | Readiness prompt | Control-plane readiness confirmed and credentials captured |
 | `vendor_defaults` | Ask whether to use the defaults (no vendor keys), BYOK, show the current official provider list, choose a non-default cascading / MLLM path, or reuse a Studio Agent ID. **Skip this gate entirely if the user has not mentioned BYOK, providers, or Studio Agent ID — defaults apply automatically.** | Code, implementation | Vendor-defaults prompt | User picks or gate is auto-skipped |
 | `vendor_selection` | Collect only provider-mode and provider choices after checking the official current provider docs | Code, implementation, secret collection | Custom-provider prompt | Provider mode and provider names are resolved |
 | `studio_agent_id` | Collect the Agora Studio Agent ID and confirm the user wants Studio to remain the source of truth for agent config | Code, re-asking provider setup from scratch | Studio-Agent-ID prompt | The Studio Agent ID path is resolved |
@@ -250,7 +273,7 @@ Before every tool call or user-visible reply:
 - If the user asks for code before quickstart resolves, answer with the next gate instead of generating code.
 - If a reply only partially resolves the current gate, ask a narrow follow-up for the missing field only.
 - If the user asks for the fastest onboarding path or mentions setup during the readiness gate, proceed directly with the CLI verification sequence and then return to the quickstart once readiness is confirmed.
-- If the user asks for the full fastest onboarding flow, proceed with the default quickstart path directly.
+- If the user asks for the full fastest onboarding flow and has not stated a stack preference, use `agent-quickstart-python`.
 - If the user names a provider that is not in the current official provider docs, say this clearly: it is **not currently documented as supported in the official Agora ConvoAI provider docs**, so do not proceed as if it is supported. Offer the documented default combo or a live-doc verification path.
 - If the user asks to see the provider list, fetch the current official provider docs and stay in the vendor gate until they accept the default combo or choose a documented alternative.
 - If the user says they already have an Agora Studio Agent ID, switch to the `studio_agent_id` state and stop re-asking provider-vendor questions unless they explicitly say they want to replace the Studio-managed config.
@@ -272,9 +295,18 @@ Suggested transition line:
 Before we jump into custom code, let's first use the official sample to get the whole flow working once. Once the agent can join the channel and finish one real conversation, we can turn that working version into your demo.
 ```
 
+### Intake
+
+Ask this right after intro when stack preference or install policy is still unknown:
+
+```text
+Before we run setup, which baseline do you want first: Python or Node/TypeScript?
+I can run environment checks automatically. If anything is missing, do you want me to install/upgrade tools for you when possible, or should I stop and ask first?
+```
+
 ### Environment Check
 
-Before starting the CLI readiness flow, verify that all runtime dependencies are installed. Auto-install missing tools where safe (`bun`, `agora` CLI), and route the user for system runtime installs (`node`, `python`) when needed.
+Before starting the CLI readiness flow, verify that all runtime dependencies are installed. Run read-only checks first, then ask before install/upgrade actions.
 
 | Dependency | Check command | Minimum version | Install if missing |
 |-----------|--------------|----------------|-------------------|
@@ -284,21 +316,21 @@ Before starting the CLI readiness flow, verify that all runtime dependencies are
 | Agora CLI | `agora version` | 0.2.0+ | `curl -fsSL https://raw.githubusercontent.com/AgoraIO/cli/main/install.sh \| sh` |
 
 Execution rules:
-- Check all four in order. If any is missing or below minimum version, install/update it before continuing.
+- Check all four in order. If any is missing or below minimum version, request approval for install/update or stop with explicit next steps.
 - For Node.js and Python, if they are not installed, tell the user what to install and wait — do not attempt to install system-level runtimes.
-- For Bun, install directly via npm.
-- For Agora CLI, prefer the official curl installer. `npm install -g agoraio-cli` is acceptable when Node 18+ is available and the package is acting as the Go binary install wrapper.
+- For Bun, ask first, then install via npm if the user approves.
+- For Agora CLI, ask first, then install with the official curl installer if the user approves. `npm install -g agoraio-cli` is acceptable when Node 18+ is available and the package is acting as the Go binary install wrapper.
 - If Agora CLI is installed but outdated, use `agora upgrade --check` for package-manager-specific guidance or reinstall from the official installer.
 - Only proceed to project readiness after all four checks pass.
 
 ### Project Readiness
 
-Do not ask the user to self-report readiness or choose between manual and CLI paths. The agent must directly execute CLI commands to check each prerequisite and, when something is missing, fix it on the spot.
+Do not ask the user to self-report readiness or choose between manual and CLI paths. The agent must directly execute CLI commands to check each prerequisite. For any mutating remediation command, ask for confirmation before executing it.
 
 Tell the user what you are about to check, then execute the commands yourself:
 
 ```text
-Let me check your project readiness — I'll use the Agora CLI to verify login, project, App ID, App Certificate, and ConvoAI activation. If anything is missing I'll fix it directly. Once the control-plane checks out I'll seed the official quickstart env file automatically.
+Let me check your project readiness — I'll use the Agora CLI to verify login, project, App ID, App Certificate, and ConvoAI activation. I'll run read-only checks first, then ask before any command that changes project state or writes files. Once the control-plane checks out, I'll seed the official quickstart env file.
 ```
 
 #### Agent execution sequence
@@ -449,7 +481,7 @@ Notes:
 
 ## After Collection
 
-Execute the default quickstart path (clone `agent-quickstart-python`, configure, run, verify first success).
+Execute the selected quickstart baseline (clone the chosen official sample, configure, run, verify first success).
 
 After first success, route by user's next request:
 

--- a/skills/agora/references/doc-fetching.md
+++ b/skills/agora/references/doc-fetching.md
@@ -52,7 +52,7 @@ using the Agora Docs MCP server, see [mcp-tools.md](mcp-tools.md).
 
 ## Agora CLI
 
-For local `agora` command-line usage, check [cli/README.md](cli/README.md) first. The bundled CLI references are verified against the installed Agora CLI `0.1.7` command surface.
+For local `agora` command-line usage, check [cli/README.md](cli/README.md) first. Treat that file as the source of truth for the currently verified CLI baseline and command surface.
 
 If the bundled CLI references do not cover a CLI-only detail, use the canonical CLI repository instead of general Agora product docs:
 

--- a/skills/agora/references/rtc/cross-platform-coordination.md
+++ b/skills/agora/references/rtc/cross-platform-coordination.md
@@ -8,6 +8,7 @@ Agora assigns UIDs per channel. For multi-platform apps:
 
 - **Auto-assign on all clients**: Pass `null`/`0` to `join()` — each platform auto-receives a unique numeric UID. Clients subscribe to all remote users regardless of platform.
 - **Fixed UIDs**: Assign specific UIDs per user role (e.g., `1001` for host, `1002` for co-host) when you need deterministic lookup. Must be unique per channel — duplicates cause undefined behavior.
+- **UID limits**: Numeric UIDs must be `0` to `2^32 - 1`. String UIDs must be ASCII and at most `255` characters.
 - **RTC + RTM coordination**: After RTC join, use `String(rtcUid)` as the RTM user ID to correlate users across both systems (see [../rtm/README.md](../rtm/README.md)).
 
 ## Codec Interoperability

--- a/skills/agora/references/rtc/react.md
+++ b/skills/agora/references/rtc/react.md
@@ -5,8 +5,9 @@ Uses the `agora-rtc-react` package, which wraps `agora-rtc-sdk-ng` with React ho
 ## Installation
 
 ```bash
-npm install agora-rtc-react agora-rtc-sdk-ng
-# agora-rtc-sdk-ng is a required peer dependency — install both.
+npm install agora-rtc-react
+# Since agora-rtc-react 2.x, you do not need to add agora-rtc-sdk-ng
+# to your app's package.json manually.
 # agora-rtc-react re-exports all agora-rtc-sdk-ng types and classes,
 # so you can import AgoraRTC and its types from either package.
 ```

--- a/skills/agora/references/rtc/react.md
+++ b/skills/agora/references/rtc/react.md
@@ -35,6 +35,8 @@ function App() {
 
 > **Codec interop**: `'vp8'` and `'vp9'` scale better in multi-user calls. `'h264'` does not scale well beyond small groups. If codecs differ between Web and native clients, Agora's server transcodes transparently (works but adds latency). See [cross-platform-coordination.md](cross-platform-coordination.md) for full interop notes.
 
+> **UID constraints**: If you pass `uid` into `useJoin`, numeric UIDs must be `0` to `2^32 - 1`; string UIDs must be ASCII and at most `255` characters. Keep UID type consistent per channel.
+
 ## Video Call Component
 
 ```tsx

--- a/skills/agora/references/rtc/web.md
+++ b/skills/agora/references/rtc/web.md
@@ -56,6 +56,12 @@ await client.setClientRole("audience") // Can only subscribe
 - `TOKEN`: Pass `null` for testing without tokens enabled. In production, always use a server-generated token.
 - `uid`: Pass `null` for auto-assignment, or a specific number. String UIDs also supported.
 
+### UID Constraints (Easy to Miss)
+
+- Numeric UID: `0` to `2^32 - 1` (32-bit unsigned integer).
+- String UID: ASCII only, maximum `255` characters.
+- Keep UID type consistent per channel: all users should use either numeric or string UIDs, not a mix.
+
 ## Creating Tracks
 
 ### Microphone Audio

--- a/skills/agora/references/server/tokens.md
+++ b/skills/agora/references/server/tokens.md
@@ -15,10 +15,11 @@ Tokens authenticate users before joining channels. Generated server-side from Ap
 
 - Numeric UID (`buildTokenWithUid` + RTC join with numeric uid): must be `0` to `2^32 - 1`.
 - String UID/account name (`buildTokenWithUserAccount` or `buildTokenWithRtm` account): ASCII only, max `255` characters.
+- **RTM / `buildTokenWithRtm` `account`**: the API expects a string. Prefer an integer user id encoded as a string of digits (for example `"12345"`), not an arbitrary alphanumeric handle, to avoid identity clashes with other services.
 - Here, `account` means the user's RTC identity string (account name), not your Agora customer account.
 - Identity and type must match end-to-end:
   - If the token is minted for numeric UID `123`, join RTC with numeric `123`.
-  - If the token is minted for account `"user-123"`, join with the same account string, not a numeric UID.
+  - If the token is minted for account `"12345"` (string carrying a numeric id — preferred), join with that exact same string identity on the client; do not substitute a different handle or assume it interchangeably maps to a numeric uid unless your SDK documents that.
 
 ## Token Generation Guides
 
@@ -29,20 +30,20 @@ Tokens authenticate users before joining channels. Generated server-side from Ap
 
 All implementations are in [AgoraIO/Tools — DynamicKey/AgoraDynamicKey](https://github.com/AgoraIO/Tools/tree/master/DynamicKey/AgoraDynamicKey):
 
-| Language | Notes |
-|----------|-------|
-| Node.js | Also available as [`agora-token`](https://www.npmjs.com/package/agora-token) on npm |
-| Python 3 | Use `python3/` directory |
-| Go | |
-| Java | |
-| C# | |
-| Dart | |
-| Deno | Native implementation — do NOT use the `agora-token` npm package in Deno |
-| Rust | |
-| PHP | |
-| Ruby | |
-| Lua | |
-| Perl | |
+| Language | Notes                                                                               |
+| -------- | ----------------------------------------------------------------------------------- |
+| Node.js  | Also available as [`agora-token`](https://www.npmjs.com/package/agora-token) on npm |
+| Python 3 | Use `python3/` directory                                                            |
+| Go       |                                                                                     |
+| Java     |                                                                                     |
+| C#       |                                                                                     |
+| Dart     |                                                                                     |
+| Deno     | Native implementation — do NOT use the `agora-token` npm package in Deno            |
+| Rust     |                                                                                     |
+| PHP      |                                                                                     |
+| Ruby     |                                                                                     |
+| Lua      |                                                                                     |
+| Perl     |                                                                                     |
 
 ## Token Types
 
@@ -60,14 +61,14 @@ Generates a combined RTC + RTM token using `AccessToken2`. Use this when you nee
 import { RtcTokenBuilder, RtcRole } from 'agora-token';
 
 const token = RtcTokenBuilder.buildTokenWithRtm(
-  appId,           // string — your Agora App ID
-  appCertificate,  // string — your App Certificate
-  channelName,     // string — channel the user will join
-  account,         // string — user account name / identity (not numeric UID)
+  appId, // string — your Agora App ID
+  appCertificate, // string — your App Certificate
+  channelName, // string — channel the user will join
+  account, // string — prefer integer user id as a string of digits (e.g. "12345")
   RtcRole.PUBLISHER,
-  tokenExpire,     // number — seconds until token expires (e.g. 3600)
-  privilegeExpire  // number — seconds until privileges expire (0 = same as tokenExpire)
+  tokenExpire, // number — seconds until token expires (e.g. 3600)
+  privilegeExpire, // number — seconds until privileges expire (0 = same as tokenExpire)
 );
 ```
 
-> **`account` vs `uid`**: `buildTokenWithRtm` takes a string `account`, not a numeric UID. When using this token for RTC, the client must join with the same account string (not a number). If your client uses numeric UIDs, use `buildTokenWithUid` instead.
+> **`account` vs `uid`**: `buildTokenWithRtm` takes a string `account`, not an integer type. Prefer passing the user's numeric id as a numeric string, and have the client join with that exact same string identity. If the RTC client joins with a numeric uid type instead, use `buildTokenWithUid` for RTC-only tokens.

--- a/skills/agora/references/server/tokens.md
+++ b/skills/agora/references/server/tokens.md
@@ -11,6 +11,15 @@ Tokens authenticate users before joining channels. Generated server-side from Ap
 - Max token validity: 24 hours
 - Use `RtcRole.SUBSCRIBER` for audience-only users (prevents stream bombing)
 
+## UID / Account-Name Constraints (Token Gotcha)
+
+- Numeric UID (`buildTokenWithUid` + RTC join with numeric uid): must be `0` to `2^32 - 1`.
+- String UID/account name (`buildTokenWithUserAccount` or `buildTokenWithRtm` account): ASCII only, max `255` characters.
+- Here, `account` means the user's RTC identity string (account name), not your Agora customer account.
+- Identity and type must match end-to-end:
+  - If the token is minted for numeric UID `123`, join RTC with numeric `123`.
+  - If the token is minted for account `"user-123"`, join with the same account string, not a numeric UID.
+
 ## Token Generation Guides
 
 - **[Deploy a Token Server](https://docs.agora.io/en/video-calling/token-authentication/deploy-token-server)** — Express/Flask/Go server examples
@@ -54,7 +63,7 @@ const token = RtcTokenBuilder.buildTokenWithRtm(
   appId,           // string — your Agora App ID
   appCertificate,  // string — your App Certificate
   channelName,     // string — channel the user will join
-  account,         // string — user account (string identity, not numeric UID)
+  account,         // string — user account name / identity (not numeric UID)
   RtcRole.PUBLISHER,
   tokenExpire,     // number — seconds until token expires (e.g. 3600)
   privilegeExpire  // number — seconds until privileges expire (0 = same as tokenExpire)


### PR DESCRIPTION
## Summary

  This updates the Agora skill docs for v1.6.1 with clearer setup behavior, corrected SDK guidance, UID/token
  gotchas, and safer quickstart onboarding.

  ## Changes

  - Corrected agora-rtc-react install guidance so apps no longer install agora-rtc-sdk-ng manually.
  - Aligned CLI guidance around current 0.2.0 behavior and removed deprecated installer flags.
  - Reordered root README installation flow so skill installation appears before Agora CLI setup.
  - Added explicit RTC UID limits:
      - numeric UID: 0 to 2^32 - 1
      - string UID/account name: ASCII, max 255 chars
  - Added UID/account-name constraints to token guidance and clarified token identity must match join identity.
  - Added consent-first ConvoAI quickstart onboarding:
      - read-only environment checks first
      - scoped setup approval before mutations
      - re-ask for high-risk actions like project creation, --overwrite, secret exposure, or system runtime installs
  - Added stack intake for first-success quickstarts:
      - Python remains default when no preference is given
      - Node/TypeScript is supported as an equal first-success path when chosen
  - Scoped dependency checks to the selected baseline instead of requiring every possible runtime.
  - Clarified agora quickstart env write as the default env seeding path and --with-secrets as explicit/manual
    fallback.
  - Added approval guidance for CLI installers and env overwrite flows.
  - Bumped skill version from 1.6.0 to 1.6.1.

  ## Validation

  - bash scripts/validate-skills.sh
  - Result: validation passed for all skill markdown/frontmatter checks.

  ## Release Type

  Patch release: documentation correctness, setup safety, and buried-gotcha discoverability.