### PR TITLE
Release/v1.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agora",
   "description": "Real-time communication with Agora SDKs — RTC, RTM, Conversational AI, and token generation",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Agora"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-05-27
+
+### Added
+
+- `skills/agora/references/conversational-ai/server-sdk-rename.md`: opt-in migration reference for projects using outdated ConvoAI server SDK package names.
+
+### Changed
+
+- `skills/agora/SKILL.md` and `skills/agora/references/conversational-ai/README.md`: route existing projects with outdated server SDK package names through the migration reference before changing manifests or imports.
+- `skills/agora/references/conversational-ai/server-sdks.md`, `python-sdk.md`, `go-sdk.md`, `auth-flow.md`, and `architecture.md`: updated default ConvoAI server SDK references to `agora-agents` and `github.com/AgoraIO/agora-agents-go`.
+
 ## [1.7.0] - 2026-05-22
 
 ### Added

--- a/agora/.cursor-plugin/plugin.json
+++ b/agora/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agora",
   "displayName": "Agora",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Official Agora workflows for voice AI, RTC, RTM, token generation, recording, and CLI onboarding.",
   "author": {
     "name": "Agora",

--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -22,10 +22,11 @@ Top-level workflow for selecting the right Agora path and loading only the refer
 1. Identify the user's primary goal from the problem they are solving.
 2. Choose exactly one primary route first: RTC, RTM, ConvoAI, CLI, Cloud Recording, Server, Server Gateway, or Cross-product coordination.
 3. Load only the primary product README first.
-4. If the task clearly spans multiple products, add the minimum supporting references after the primary route is chosen.
-5. If the request matches ConvoAI and there is no proven working baseline yet, stop and follow the quickstart path before generating custom code from memory or scaffolding a replacement app.
-6. Ask one short clarification only if the route is still ambiguous after checking the obvious cues below.
-7. Use Level 2 documentation lookup only when the local references do not cover the needed detail.
+4. When the ConvoAI route is chosen and read-only workspace detection finds outdated server SDK package or module names — or the user asks to migrate — load **[references/conversational-ai/server-sdk-rename.md](references/conversational-ai/server-sdk-rename.md)** before editing manifests or imports. Do not load it for greenfield ConvoAI work.
+5. If the task clearly spans multiple products, add the minimum supporting references after the primary route is chosen.
+6. If the request matches ConvoAI and there is no proven working baseline yet, stop and follow the quickstart path before generating custom code from memory or scaffolding a replacement app.
+7. Ask one short clarification only if the route is still ambiguous after checking the obvious cues below.
+8. Use Level 2 documentation lookup only when the local references do not cover the needed detail.
 
 ## Route Selection
 

--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   integrating Agora into an app.
 metadata:
   author: agora
-  version: '1.7.0'
+  version: '1.8.0'
 ---
 
 <!-- applies-from: v0.2.1 -->

--- a/skills/agora/references/conversational-ai/README.md
+++ b/skills/agora/references/conversational-ai/README.md
@@ -20,6 +20,7 @@ The key question: does the user already have a **working ConvoAI baseline**?
 | `quickstart` | New project, first demo, wants the official baseline, or has a cloned sample that is not proven end to end | [quickstarts.md](quickstarts.md) |
 | `integration` | Has an existing application or multi-project workspace and wants ConvoAI added | [quickstarts.md](quickstarts.md) to clone/inspect the official source, then [integration-from-quickstart.md](integration-from-quickstart.md) for app integration |
 | `backend-implementation` | Working baseline confirmed, now needs server code or lifecycle/auth changes | [server-sdks.md](server-sdks.md), [python-sdk.md](python-sdk.md), [go-sdk.md](go-sdk.md), or [auth-flow.md](auth-flow.md) |
+| `server-sdk-rename` | Existing project uses outdated server SDK package/module names, or user asks to migrate | [server-sdk-rename.md](server-sdk-rename.md) |
 | `client-customization` | Working baseline confirmed, now needs transcripts, hooks, UI, or mobile client work | [agent-toolkit.md](agent-toolkit.md), [agent-client-toolkit-react.md](agent-client-toolkit-react.md), [agent-ui-kit.md](agent-ui-kit.md), [agent-toolkit-ios.md](agent-toolkit-ios.md), [agent-toolkit-android.md](agent-toolkit-android.md) |
 | `studio-agent` | The user already has an Agora Studio Agent ID and wants to reuse that Studio-managed agent config | [quickstarts.md](quickstarts.md), then [conversational-ai-studio.md](conversational-ai-studio.md) |
 | `advanced-feature` / `debugging` / `ops-hardening` | Working baseline confirmed, wants custom LLM, memory, webhooks, production hardening, or error diagnosis | Start in this file, then route to the relevant reference below |
@@ -31,6 +32,7 @@ The key question: does the user already have a **working ConvoAI baseline**?
 - While quickstart is unresolved, do **not** generate `/join` payloads, propose a custom project structure, or jump straight into SDK code.
 - Existing RTC code, a checked-out repo, or a cloned quickstart is not enough to skip quickstart; the ConvoAI path must already work once.
 - If the user has an existing app, classify the request as `integration`: first clone or inspect the official quickstart as source, then use [integration-from-quickstart.md](integration-from-quickstart.md) to detect the app shape, produce a copy map, and adapt only the needed pieces. Runtime proof should happen before declaring the integration works, but the reason for the quickstart is source alignment, not proving Agora's sample exists.
+- Before generating server SDK install or import changes in an existing codebase, scan dependency manifests and import strings. If outdated server SDK names are present, load [server-sdk-rename.md](server-sdk-rename.md) first, apply the rename map, then continue in [server-sdks.md](server-sdks.md) / [python-sdk.md](python-sdk.md) / [go-sdk.md](go-sdk.md).
 - For `integration`, detect first and ask last: use session memory, then read-only workspace detection, then one focused question only if required. Do not re-ask for values the user already provided.
 - Follow the silent-by-default response contract and recovery rule from [../../SKILL.md](../../SKILL.md) and [quickstarts.md](quickstarts.md): check the baseline gate internally on every actionable reply, but show user-facing state only on first reply, gate flips, blocked actions, or status requests.
 - If the user explicitly says the baseline already works, skip quickstart and route directly to the relevant implementation file.
@@ -70,9 +72,9 @@ Important:
 
 | Backend language | Path |
 |---|---|
-| TypeScript / Node.js | `agora-agent-server-sdk` — see [server-sdks.md](server-sdks.md) |
-| Python | `agora-agent` — see [python-sdk.md](python-sdk.md) |
-| Go | `agora-agent-server-sdk-go` — see [go-sdk.md](go-sdk.md) |
+| TypeScript / Node.js | `agora-agents` — see [server-sdks.md](server-sdks.md) |
+| Python | `agora-agents` (import `agora_agent`) — see [python-sdk.md](python-sdk.md) |
+| Go | `github.com/AgoraIO/agora-agents-go` — see [go-sdk.md](go-sdk.md) |
 | Java, Ruby, PHP, C#, other | Call the REST API directly — see [auth-flow.md](auth-flow.md) |
 
 Direct REST API use is fully supported for languages without an SDK. The [auth-flow.md](auth-flow.md) file covers the end-to-end auth and token flow for REST API implementors. If the user has an SDK available, start with that instead — the SDK eliminates the need to manually build tokens for the ConvoAI server.

--- a/skills/agora/references/conversational-ai/architecture.md
+++ b/skills/agora/references/conversational-ai/architecture.md
@@ -132,7 +132,7 @@ See [auth-flow.md](auth-flow.md) and [../server/tokens.md](../server/tokens.md).
 
 ### Server SDK session states
 
-When using `agora-agent-server-sdk`, map platform lifecycle to SDK session states:
+When using `agora-agents`, map platform lifecycle to SDK session states:
 
 | SDK state           | Typical action                               |
 | ------------------- | -------------------------------------------- |

--- a/skills/agora/references/conversational-ai/auth-flow.md
+++ b/skills/agora/references/conversational-ai/auth-flow.md
@@ -81,7 +81,7 @@ const rtmToken = RtmTokenBuilder.buildToken(
 Using App Credentials mode — the SDK generates the ConvoAI token automatically:
 
 ```typescript
-import { AgoraClient, Agent } from 'agora-agent-server-sdk';
+import { AgoraClient, Agent } from 'agora-agents';
 
 const client = new AgoraClient({
   appId: process.env.AGORA_APP_ID,

--- a/skills/agora/references/conversational-ai/go-sdk.md
+++ b/skills/agora/references/conversational-ai/go-sdk.md
@@ -3,8 +3,8 @@ name: agora-server-sdk-go
 description: |
   Go SDK for Agora Conversational AI server-side integration. Use when the user is
   building a Go backend to start/stop/manage ConvoAI agents. Triggers on:
-  agora-agent-server-sdk-go, agentkit Go, AgentSession Go, Go ConvoAI server,
-  context.Context agent, go get agora agent.
+  agora-agents-go, github.com/AgoraIO/agora-agents-go, agentkit Go,
+  AgentSession Go, Go ConvoAI server, context.Context agent, go get agora agent.
 license: MIT
 metadata:
   author: agora
@@ -15,14 +15,14 @@ metadata:
 
 Go SDK for managing Agora Conversational AI agents from a server-side application. Wraps the ConvoAI REST API.
 
-**Module:** `github.com/AgoraIO-Community/agora-agent-server-sdk-go`
+**Module:** `github.com/AgoraIO/agora-agents-go`
 **Minimum Go version:** 1.21
-**Repo:** <https://github.com/AgoraIO-Conversational-AI/agent-server-sdk-go>
+**Repo:** <https://github.com/AgoraIO/agora-agents-go>
 
 ## Installation
 
 ```bash
-go get github.com/AgoraIO-Community/agora-agent-server-sdk-go
+go get github.com/AgoraIO/agora-agents-go
 ```
 
 ## Quick Start
@@ -36,7 +36,7 @@ import (
     "log"
     "time"
 
-    "github.com/AgoraIO-Community/agora-agent-server-sdk-go/agentkit"
+    "github.com/AgoraIO/agora-agents-go/agentkit"
 )
 
 func main() {

--- a/skills/agora/references/conversational-ai/python-sdk.md
+++ b/skills/agora/references/conversational-ai/python-sdk.md
@@ -3,8 +3,8 @@ name: agora-server-sdk-python
 description: |
   Python SDK for Agora Conversational AI server-side integration. Use when the user is
   building a Python backend to start/stop/manage ConvoAI agents. Triggers on:
-  agora-agent Python, agent_server_sdk_python, AsyncAgora, AsyncAgentSession, pip install
-  agora-agent, Python ConvoAI server, agora_agent.
+  agora-agents Python, agent_server_sdk_python, AsyncAgora, AsyncAgentSession,
+  pip install agora-agents, Python ConvoAI server, agora_agent.
 license: MIT
 metadata:
   author: agora
@@ -15,15 +15,15 @@ metadata:
 
 Python SDK for managing Agora Conversational AI agents from a server-side application. Wraps the ConvoAI REST API.
 
-**Package:** `agora-agent`
+**Package:** `agora-agents`
 **Repo:** <https://github.com/AgoraIO-Conversational-AI/agent-server-sdk-python>
 
 ## Installation
 
 ```bash
-pip install agora-agent
+pip install agora-agents
 # or with Poetry:
-poetry add agora-agent
+poetry add agora-agents
 ```
 
 ## Sync vs Async

--- a/skills/agora/references/conversational-ai/server-sdk-rename.md
+++ b/skills/agora/references/conversational-ai/server-sdk-rename.md
@@ -1,0 +1,78 @@
+---
+name: agora-server-sdk-rename
+description: |
+  Opt-in only. Load when the user's project uses outdated ConvoAI server SDK package or
+  module names and they need to migrate to current names. Do not load for greenfield work.
+  Triggers on: agora-agent-server-sdk, agora-agent (PyPI), agora-agent-server-sdk-go,
+  AgoraIO-Community/agora-agent-server-sdk-go, migrate agora sdk, upgrade server sdk package.
+license: MIT
+metadata:
+  author: agora
+  version: '1.0.0'
+---
+
+# ConvoAI Server SDK — package rename migration
+
+> **Opt-in only.** Load this file when workspace detection or the user shows outdated server SDK names. Default ConvoAI routing uses [server-sdks.md](server-sdks.md), [python-sdk.md](python-sdk.md), and [go-sdk.md](go-sdk.md) with current names.
+
+Apply the renames below in dependency manifests and import statements. The public API is unchanged — only install paths and import strings move.
+
+## Detection signals
+
+Scan the user's project (read-only) for any of:
+
+| Signal | Where to look |
+|--------|----------------|
+| `agora-agent-server-sdk` | `package.json`, lockfiles, `import` / `require` strings |
+| `agora-agent` (not `agora-agents`) | `pyproject.toml`, `requirements.txt`, `Pipfile`, `poetry.lock` |
+| `github.com/AgoraIO-Community/agora-agent-server-sdk-go` | `go.mod`, Go import paths |
+| `agent-server-sdk-go` repo URL | README, CI config, docs |
+
+If none match, do not load this file.
+
+## Rename map
+
+### TypeScript / npm
+
+| Update | From | To |
+|--------|------|-----|
+| Dependency | `agora-agent-server-sdk` | `agora-agents` |
+| Import | `from 'agora-agent-server-sdk'` | `from 'agora-agents'` |
+
+The npm package `agora-agent-server-sdk` still resolves via a compat shim, but new projects and migrations should use `agora-agents`.
+
+### Python / PyPI
+
+| Update | From | To |
+|--------|------|-----|
+| Dependency | `agora-agent` or `agora-agent-server-sdk` | `agora-agents` |
+| Import | `from agora_agent import ...` | **No change** |
+
+Only the PyPI install name changes. Python import paths stay `agora_agent`.
+
+### Go
+
+| Update | From | To |
+|--------|------|-----|
+| Module | `github.com/AgoraIO-Community/agora-agent-server-sdk-go` | `github.com/AgoraIO/agora-agents-go` |
+| Imports | `.../agora-agent-server-sdk-go/...` | `github.com/AgoraIO/agora-agents-go/...` |
+| Repo | `AgoraIO-Conversational-AI/agent-server-sdk-go` | `AgoraIO/agora-agents-go` |
+
+Go has no module alias — update `go.mod` and all import paths together, then `go mod tidy`.
+
+## Migration steps
+
+1. Update the manifest (`package.json`, `pyproject.toml` / `requirements.txt`, or `go.mod`).
+2. Replace import strings in source files per the table above.
+3. Reinstall / tidy (`npm install`, `pip install -r ...`, or `go mod tidy`).
+4. Run the project's test suite or a minimal start/stop agent smoke test.
+
+Do not change application logic, env var names, or AgentKit builder code — the API surface is the same.
+
+## After migration
+
+Route back to the current SDK references for ongoing work:
+
+- TypeScript: [server-sdks.md](server-sdks.md)
+- Python: [python-sdk.md](python-sdk.md)
+- Go: [go-sdk.md](go-sdk.md)

--- a/skills/agora/references/conversational-ai/server-sdks.md
+++ b/skills/agora/references/conversational-ai/server-sdks.md
@@ -3,7 +3,7 @@ name: agora-convoai-server-sdks
 description: |
   Server-side SDKs for Agora Conversational AI: TypeScript, Python, and Go wrappers around the
   ConvoAI REST API. Use when the user is building a backend to start/stop/manage ConvoAI agents.
-  Triggers on: agora-agent-server-sdk, AgoraClient, AgentSession, session.start, session.stop,
+  Triggers on: agora-agents, AgoraClient, AgentSession, session.start, session.stop,
   agent server SDK, ConvoAI backend, ConvoAI server, withStt, withLlm, withTts.
 license: MIT
 metadata:
@@ -17,16 +17,16 @@ metadata:
 
 TypeScript, Go, and Python SDKs — convenience wrappers around the ConvoAI REST API. For any other backend language, call the REST API directly. Fetch the live OpenAPI spec for the full schema: `https://docs-md.agora.io/api/conversational-ai-api-v2.x.yaml`
 
-## TypeScript — `agora-agent-server-sdk`
+## TypeScript — `agora-agents`
 
 ```bash
-npm install agora-agent-server-sdk
+npm install agora-agents
 ```
 
 Builder pattern — configure the AI pipeline then create sessions:
 
 ```typescript
-import { AgoraClient, Agent, Area } from 'agora-agent-server-sdk';
+import { AgoraClient, Agent, Area } from 'agora-agents';
 
 const client = new AgoraClient({
   area: Area.US,


### PR DESCRIPTION
## Summary

  Prepare the Agora skill for the ConvoAI server SDK package rename and bump the
  release to `v1.8.0`.

  ## Changes

  - Add an opt-in ConvoAI server SDK package rename migration reference.
  - Route existing projects with outdated server SDK package/module names
  through the migration reference before editing manifests or imports.
  - Update default ConvoAI server SDK docs to current package names:
    - TypeScript: `agora-agents`
    - Python: `agora-agents` with unchanged `agora_agent` imports
    - Go: `github.com/AgoraIO/agora-agents-go`
  - Update TypeScript, Python, Go, auth-flow, and architecture references to
  avoid old package names in default docs.
  - Bump Agora skill/plugin metadata to `1.8.0`.
  - Add `CHANGELOG.md` entry for `1.8.0`.

  ## Validation

  - Verified old server SDK names only remain in the opt-in migration reference.
  - Verified current package names appear in default ConvoAI SDK references.
  - Verified migration routing is wired from the top-level skill and ConvoAI
  README.
  - Ran `git diff --check`.