### PR TITLE
Release v1.8.1: fix plugin submission package

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "agora",
       "source": "./",
       "description": "Real-time communication with Agora SDKs — RTC, RTM, Conversational AI, and token generation",
-      "version": "1.7.0"
+      "version": "1.8.1"
     }
   ]
 }

--- a/.claude-plugin/mcp-config.json
+++ b/.claude-plugin/mcp-config.json
@@ -1,6 +1,8 @@
 {
-  "agora-docs": {
-    "type": "http",
-    "url": "https://mcp.agora.io"
+  "mcpServers": {
+    "agora-docs-mcp": {
+      "type": "http",
+      "url": "https://mcp.agora.io"
+    }
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agora",
   "description": "Real-time communication with Agora SDKs — RTC, RTM, Conversational AI, and token generation",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Agora"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-06-26
+
+### Fixed
+
+- `.claude-plugin/mcp-config.json`: wrap server definition with `mcpServers` key and rename the server `agora-docs` → `agora-docs-mcp` so the Claude Code plugin loader registers it under the name referenced in `skills/agora/SKILL.md` and `skills/agora/references/mcp-tools.md`.
+- `.claude-plugin/marketplace.json`: align version with `plugin.json` and `skills/agora/SKILL.md` (1.7.0 → 1.8.1).
+- `README.md`: fix malformed "Powered by Agora" link and point Contributing at the in-repo `CONTRIBUTING.md` instead of a feature branch.
+
+### Changed
+
+- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `skills/agora/SKILL.md`: bump version to 1.8.1 so anyone who installed 1.8.0 picks up the working `mcp-config.json`.
+- `skills/agora/references/mcp-tools.md`: update install command and remove the obsolete "configured here as `agora-docs`" caveat now that the server name matches.
+
 ## [1.8.0] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ The skill files are plain markdown. Use `skills/agora/SKILL.md` as the entry poi
 
 ## Contributing
 
-See[ `CONTRIBUTING.md`](https://github.com/AgoraIO/skills/blob/feat/readme-and-description-rewrite/CONTRIBUTING.md).
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## About
 
-Powered by [Agora](agora.io)(agora.io) — the real-time engagement platform behind voice, video, messaging, and interactive AI experiences.
+Powered by [Agora](https://agora.io) — the real-time engagement platform behind voice, video, messaging, and interactive AI experiences.
 
 - Agora Documentation: [https://docs.agora.io/](https://docs.agora.io/)
 - Agora Console: [https://console.agora.io/](https://console.agora.io/)

--- a/skills/agora/SKILL.md
+++ b/skills/agora/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   integrating Agora into an app.
 metadata:
   author: agora
-  version: '1.8.0'
+  version: '1.8.1'
 ---
 
 <!-- applies-from: v0.2.1 -->

--- a/skills/agora/references/mcp-tools.md
+++ b/skills/agora/references/mcp-tools.md
@@ -2,8 +2,7 @@
 
 <!-- applies-from: v0.2.0 -->
 
-The Agora Docs MCP server (`agora-docs-mcp`, configured here as `agora-docs`)
-gives AI assistants direct tool-call access to Agora documentation. It is an
+The Agora Docs MCP server (`agora-docs-mcp`) gives AI assistants direct tool-call access to Agora documentation. It is an
 optional enhancement — the skill works without it using the two-tier fetch
 approach in [doc-fetching.md](doc-fetching.md).
 
@@ -32,7 +31,7 @@ directly when the URI is known.
 
 **Claude Code:**
 ```bash
-claude mcp add agora-docs --transport http https://mcp.agora.io
+claude mcp add agora-docs-mcp --transport http https://mcp.agora.io
 ```
 
 **Cursor / Windsurf / other MCP-compatible tools:** Add `https://mcp.agora.io` as


### PR DESCRIPTION
Release v1.8.1 — submission-readiness fixes for https://claude.com/plugins. All changes are small, targeted, and required for the plugin to load.

Fixes

- mcp-config.json was a bare server object. The Claude Code plugin loader expects a top-level mcpServers key. Without it, the plugin parses as having no MCP servers. Wrapped the config and renamed the server agora-docs → agora-docs-mcp so it matches the name used in SKILL.md and references/mcp-tools.md.
- Version drift across plugin manifests. plugin.json and SKILL.md said 1.8.0, marketplace.json still said 1.7.0. Bumped all three to 1.8.1 so anyone who already installed 1.8.0 picks up the working mcp-config.json on next update.
- README links. "Powered by Agora" was a malformed double link [Agora](agora.io)(agora.io). Contributing pointed at a feature-branch URL instead of the file in this repo. Both fixed.

Validation

$ bash scripts/validate-skills.sh
Validation passed: 2 skills, 12 frontmatter files, 55 markdown files checked.

$ claude plugin validate ./
Validating marketplace manifest: .../.claude-plugin/marketplace.json
✔ Validation passed

Files changed

.claude-plugin/marketplace.json      | 2 +-
.claude-plugin/mcp-config.json       | 8 +++++---
.claude-plugin/plugin.json           | 2 +-
README.md                            | 4 ++--
skills/agora/SKILL.md                | 2 +-
skills/agora/references/mcp-tools.md | 5 ++---

Test plan

- bash scripts/validate-skills.sh passes locally
- claude plugin validate ./ passes locally
- claude --plugin-dir ./ loads the plugin and the agora-docs-mcp HTTP server connects to https://mcp.agora.io
- After merge, tag v1.8.1 and cut the GitHub Release

Checklist

- Freeze-forever test applied to all new inline content — would it still be correct if never updated?
- Routing still correct from skills/agora/SKILL.md
- New or changed local links are valid
- No duplicate skill names
- No absolute local paths (/Users/...)
- No hardcoded credentials or API keys
- At least one eval case added or updated in tests/eval-cases.md — N/A, config/release fix only
- If adding code generation guidance: testing guidance updated — N/A
- scripts/validate-skills.sh passes locally