### PR TITLE
docs(cli): clarify project creation region handling

### DIFF
--- a/skills/agora/references/cli/projects.md
+++ b/skills/agora/references/cli/projects.md
@@ -28,11 +28,19 @@ agora project list --refresh-cache
 ### Create
 
 ```bash
-agora project create <name> [--region global|cn] [--template voice-agent] [--feature rtc|rtm|convoai]
+agora project create <name> [--template voice-agent] [--feature rtc|rtm|convoai]
 agora project create <name> --dry-run
 agora project create <name> --idempotency-key <key>
 agora project create <name> --rtm-data-center EU
 ```
+
+Project creation uses the active login region. Resolve the region using the
+login flow in [install-auth.md](install-auth.md); do not ask the user to choose
+a region. When repository or session state indicates a non-default region, run
+`agora login --region <region>` before `agora project create`.
+
+CLI `0.2.1` accepted `--region` directly on `project create`, but later releases
+removed that flag. Do not pass `--region` to `project create`.
 
 For agent guidance, prefer explicit `--feature` flags because they match the later `project feature` workflow. Omitted `--feature` defaults to `rtc`, `rtm`, and `convoai`, and `convoai` implies `rtm`.
 


### PR DESCRIPTION
## Summary

- remove the deprecated `--region` flag from `agora project create`
- clarify that project creation uses the active login region
- document the CLI 0.2.1 compatibility difference

## Validation

- `bash scripts/validate-skills.sh`
- `git diff --check`

This is a one-commit follow-up for #48. Merging it updates the source branch of #48 directly.