### PR TITLE
ci: move Anthropic sync to maintained fork

### DIFF
--- a/.github/workflows/sync-anthropics-fork.yml
+++ b/.github/workflows/sync-anthropics-fork.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
-      TARGET_REPO: AgoraIO/skills
+      TARGET_REPO: littleDogWang/skills
       TARGET_BRANCH: sync/voice-ai-integration
       TARGET_PATH: skills/voice-ai-integration
 
@@ -87,4 +87,4 @@ jobs:
       - name: Print upstream PR URL
         run: |
           echo "Open this URL to create or update the upstream PR manually:"
-          echo "https://github.com/anthropics/skills/compare/main...AgoraIO:${TARGET_BRANCH}?expand=1"
+          echo "https://github.com/anthropics/skills/compare/main...littleDogWang:${TARGET_BRANCH}?expand=1"


### PR DESCRIPTION
## Summary

- push the exported `voice-ai-integration` bundle to `littleDogWang/skills`
- print the Anthropic compare URL for the maintained fork
- retain the existing `ANTHROPICS_SKILLS_SYNC_TOKEN` secret contract

The previous sync owner has left Agora. The existing upstream PR anthropics/skills#1063 is tied to that owner's fork and cannot be retargeted.

## Validation

- `bash scripts/validate-skills.sh`
- YAML parse via Ruby
- `bash scripts/export-anthropic-skill.sh <temp-dir>`
- `git diff --check`

After merge, replace `ANTHROPICS_SKILLS_SYNC_TOKEN` with a fine-grained PAT that can write to `littleDogWang/skills`, then rerun the sync workflow.