### PR TITLE
fix: stabilize evaluator workflows and reporting

### DIFF
--- a/.github/actions/setup-eval-harness/action.yml
+++ b/.github/actions/setup-eval-harness/action.yml
@@ -31,6 +31,10 @@ runs:
           echo "::error::No eval ref resolved (set eval_ref input or .github/eval-pin.env)"
           exit 1
         fi
+        if [[ "$REF" =~ ^[0-9a-fA-F]{1,39}$ ]]; then
+          echo "::error::eval_ref looks like a shortened commit SHA. Use a full 40-character SHA, branch, or tag."
+          exit 1
+        fi
         echo "ref=${REF}" >> "$GITHUB_OUTPUT"
 
     - name: Clone agentic-evals

--- a/.github/eval-pin.env
+++ b/.github/eval-pin.env
@@ -1,3 +1,3 @@
 # Pinned agentic-evals commit for skills PR evals.
 # Bump after validating a new harness release on main.
-EVAL_REF=b0d72adf05ee0b98f1864896215409394da74cb9
+EVAL_REF=dae8e7790093ae5946fb0da348f63d519f8058da

--- a/.github/eval-pin.env
+++ b/.github/eval-pin.env
@@ -1,3 +1,3 @@
 # Pinned agentic-evals commit for skills PR evals.
 # Bump after validating a new harness release on main.
-EVAL_REF=8bc269745c4d88dfd7b1f6d1e3ec601c71e3116a
+EVAL_REF=fd1a5ae10ddbb53cc55e311079ca108ee23d36d4

--- a/.github/eval-pin.env
+++ b/.github/eval-pin.env
@@ -1,3 +1,3 @@
 # Pinned agentic-evals commit for skills PR evals.
 # Bump after validating a new harness release on main.
-EVAL_REF=fd1a5ae10ddbb53cc55e311079ca108ee23d36d4
+EVAL_REF=b0d72adf05ee0b98f1864896215409394da74cb9

--- a/.github/workflows/codex-eval.yml
+++ b/.github/workflows/codex-eval.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Setup eval harness
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
+          eval_repo: littleDogWang/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Validate YAML
@@ -69,7 +70,10 @@ jobs:
       - name: Install runtime dependencies
         run: |
           pip install pyyaml
-          npm install -g agent-browser @openai/codex
+          npm install -g --allow-scripts=agent-browser agent-browser @openai/codex
+          agent-browser install
+          agent-browser --version
+          codex --version
 
       - name: Write credentials file
         env:
@@ -104,6 +108,9 @@ jobs:
           Key rules:
           - Use spawn_agent with fork_context: false for each case.
           - Do NOT use codex exec as a substitute for per-case execution.
+          - agent-browser and its Chrome runtime are installed. For browser assertions,
+            invoke the agent-browser CLI through shell commands; do not infer that browser
+            verification is unavailable only because it is not exposed as a native tool.
           - Create isolated workspaces via the helper script:
             bash .agents/skills/skills-evaluation/scripts/create_case_workspace.sh
           - Collect evidence from ~/.codex/sessions/ after each sub-agent completes.
@@ -154,16 +161,13 @@ jobs:
         env:
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
           MODEL: ${{ github.event.inputs.model || 'gpt-5.4' }}
         run: |
           set -e
 
-          run_codex_once() {
-            local attempt="$1"
-            local log_file="$2"
-            local output_file="$3"
+          configure_codex() {
             mkdir -p "$HOME/.codex"
             base_url="${RESPONSES_API_ENDPOINT%/responses}"
             base_url="${base_url%/}/v1"
@@ -171,6 +175,13 @@ jobs:
           model_provider = "OpenAI"
           model = "${MODEL}"
           disable_response_storage = true
+
+          [features]
+          multi_agent = true
+          multi_agent_v2 = true
+
+          [agents]
+          enabled = true
 
           [model_providers.OpenAI]
           name = "OpenAI"
@@ -183,8 +194,39 @@ jobs:
           {"auth_mode":"apikey","OPENAI_API_KEY":"${OPENAI_API_KEY}"}
           EOF
             fi
+          }
 
-            codex exec --skip-git-repo-check --sandbox danger-full-access \
+          configure_codex
+          codex --version
+          codex features list --enable multi_agent --enable multi_agent_v2 | \
+            grep -E '^multi_agent(_v2)?[[:space:]]+stable[[:space:]]+true$'
+
+          preflight_marker="/tmp/codex-subagent-preflight.marker"
+          preflight_output="/tmp/codex-subagent-preflight.md"
+          preflight_child_marker="/tmp/codex-subagent-preflight-child.marker"
+          : > "$preflight_marker"
+          : > "$preflight_output"
+          : > "$preflight_child_marker"
+          cat > /tmp/codex-subagent-preflight.txt << 'HEREDOC'
+          Use spawn_agent with fork_context: false to start one fresh child agent.
+          Ask the child to overwrite /tmp/codex-subagent-preflight-child.marker with exactly: SUBAGENT_CHILD_EXECUTED
+          Then ask the child to reply exactly: SUBAGENT_PREFLIGHT_OK
+          Wait for the child to finish, then reply exactly: SUBAGENT_PREFLIGHT_OK
+          HEREDOC
+          codex exec --enable multi_agent --enable multi_agent_v2 \
+            --skip-git-repo-check --sandbox danger-full-access \
+            --output-last-message "$preflight_output" < /tmp/codex-subagent-preflight.txt
+          grep -qx 'SUBAGENT_PREFLIGHT_OK' "$preflight_output"
+          grep -qx 'SUBAGENT_CHILD_EXECUTED' "$preflight_child_marker"
+          find "$HOME/.codex/sessions" -type f -name '*.jsonl' -newer "$preflight_marker" \
+            -exec grep -l 'subagent' {} + | grep -q .
+
+          run_codex_once() {
+            local attempt="$1"
+            local log_file="$2"
+            local output_file="$3"
+            codex exec --enable multi_agent --enable multi_agent_v2 \
+              --skip-git-repo-check --sandbox danger-full-access \
               --output-last-message "${output_file}" < /tmp/eval-prompt.txt \
               > "${log_file}" 2>&1
           }

--- a/.github/workflows/codex-eval.yml
+++ b/.github/workflows/codex-eval.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup eval harness
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          eval_repo: littleDogWang/agentic-evals
+          eval_repo: AgoraIO/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Validate YAML
@@ -86,102 +86,73 @@ jobs:
           EOF
           chmod 600 /tmp/agora-credentials.env
 
-      - name: Build evaluator prompt
+      - name: Resolve cases
+        id: resolve
+        working-directory: agentic-evals
         env:
           SUITE_IDS: ${{ github.event.inputs.suite_ids || 'workflow' }}
           CASE_ID: ${{ github.event.inputs.case_id || 'convoai-e2e-first-success' }}
         run: |
-          EFFECTIVE_CASE_ID="${CASE_ID}"
-          EFFECTIVE_SUITE_IDS="${SUITE_IDS}"
+          python3 - <<'PY'
+          import datetime
+          import json
+          import os
+          import yaml
 
-          EVAL_DIR="$(pwd)/agentic-evals"
+          target_id = os.environ["TARGET_ID"]
+          suite_ids = os.environ["SUITE_IDS"]
+          case_id = os.environ["CASE_ID"]
+          target = yaml.safe_load(open(f"targets/{target_id}/target.yaml"))
+          selected_suites = target["default_suites"] if suite_ids == "all" else [item.strip() for item in suite_ids.split(",")]
+          cases = []
+          for suite_id in selected_suites:
+              suite = yaml.safe_load(open(f"targets/{target_id}/cases/{suite_id}/suite.yaml"))
+              for case_path in suite["cases"]:
+                  case = yaml.safe_load(open(case_path))
+                  if case_id and case["case_id"] != case_id:
+                      continue
+                  cases.append({"case_id": case["case_id"], "path": case_path, "user_prompt": case["input"]["user_prompt"]})
+          if not cases:
+              raise SystemExit("No cases resolved.")
+          started = datetime.datetime.now(datetime.timezone.utc)
+          run_id = f"codex-{started.strftime('%Y%m%dT%H%M%SZ')}"
+          run_dir = f"runs/{run_id}"
+          os.makedirs(f"{run_dir}/case-artifacts", exist_ok=True)
+          os.makedirs(f"{run_dir}/case-results", exist_ok=True)
+          manifest = {
+              "run_mode": "single-run",
+              "run_id": run_id,
+              "runtime": "codex-cli-direct",
+              "target_id": target_id,
+              "suite_ids": selected_suites,
+              "case_ids": [case["case_id"] for case in cases],
+              "started_at": started.isoformat(),
+              "workspace_mode": "isolated-per-case",
+              "evidence_mode": "codex-direct-process",
+          }
+          json.dump(manifest, open(f"{run_dir}/manifest.json", "w"), indent=2)
+          json.dump(cases, open("/tmp/codex-eval-cases.json", "w"))
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"run_dir={run_dir}\n")
+          PY
 
-          cat > /tmp/eval-prompt.txt << 'HEREDOC'
-          You are the skill-eval evaluator agent.
-
-          Instructions:
-          1. Read AGENT.md (canonical repo contract).
-          2. Read .agents/skills/skills-evaluation/SKILL.md (operational instructions).
-          3. Read docs/session-evidence.md (evidence contract).
-          4. Follow the SKILL.md workflow exactly.
-
-          Key rules:
-          - Use spawn_agent with fork_context: false for each case.
-          - Do NOT use codex exec as a substitute for per-case execution.
-          - agent-browser and its Chrome runtime are installed. For browser assertions,
-            invoke the agent-browser CLI through shell commands; do not infer that browser
-            verification is unavailable only because it is not exposed as a native tool.
-          - Create isolated workspaces via the helper script:
-            bash .agents/skills/skills-evaluation/scripts/create_case_workspace.sh
-          - Collect evidence from ~/.codex/sessions/ after each sub-agent completes.
-          - Write all artifacts under runs/<run_id>/.
-
-          Timing requirements:
-          - Record wall-clock timestamps (ISO 8601 UTC) for each case.
-          - Track two phases separately:
-            - "Task execution": from agent receiving the prompt to delivering its final answer.
-            - "Verification": from evidence collection start to all artifacts written.
-          - In report.md, include a "## Timing" section with a human-readable table:
-            | case_id | task_execution | verification | total |
-            Use human-friendly durations like "3m 12s" instead of raw seconds.
-          - In each case-results/<case_id>.json, include timestamps and durations for both phases.
-
-          Report quality requirements:
-          - For each failed assertion, explain WHAT went wrong with specifics (quote actual commands/output).
-          - For each passed assertion, include a one-line evidence summary.
-          - "Suggested Next Fixes" must include concrete actions, not just file paths.
-          - If evaluator browser verification was skipped or degraded, note it but do not fail the case.
-          HEREDOC
-
-          echo "" >> /tmp/eval-prompt.txt
-          echo "Agora credentials file: /tmp/agora-credentials.env" >> /tmp/eval-prompt.txt
-          echo "Before spawning each sub-agent, source this file so AGORA_APP_ID and AGORA_APP_CERTIFICATE are exported." >> /tmp/eval-prompt.txt
-          echo "Do NOT echo or log the credential values." >> /tmp/eval-prompt.txt
-          echo "" >> /tmp/eval-prompt.txt
-          echo "Run parameters:" >> /tmp/eval-prompt.txt
-          echo "- test repo path: ${EVAL_DIR}" >> /tmp/eval-prompt.txt
-          echo "- target_id: ${TARGET_ID}" >> /tmp/eval-prompt.txt
-          echo "- run_mode: single-run" >> /tmp/eval-prompt.txt
-
-          if [ "$EFFECTIVE_SUITE_IDS" != "all" ]; then
-            echo "- suite_ids: ${EFFECTIVE_SUITE_IDS}" >> /tmp/eval-prompt.txt
-          else
-            echo "- suite_ids: use target defaults" >> /tmp/eval-prompt.txt
-          fi
-
-          if [ -n "$EFFECTIVE_CASE_ID" ]; then
-            echo "- case_id: ${EFFECTIVE_CASE_ID}" >> /tmp/eval-prompt.txt
-          fi
-
-          echo "" >> /tmp/eval-prompt.txt
-          echo "Begin the evaluation now." >> /tmp/eval-prompt.txt
-
-      - name: Run Codex evaluator with stream-safe retry
-        id: run_codex
+      - name: Run direct Codex case sessions
         env:
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
-          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
           MODEL: ${{ github.event.inputs.model || 'gpt-5.4' }}
+          RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
+        working-directory: agentic-evals
         run: |
           set -e
-
-          configure_codex() {
-            mkdir -p "$HOME/.codex"
-            base_url="${RESPONSES_API_ENDPOINT%/responses}"
-            base_url="${base_url%/}/v1"
-            cat > "$HOME/.codex/config.toml" << EOF
+          mkdir -p "$HOME/.codex"
+          base_url="${RESPONSES_API_ENDPOINT%/responses}"
+          base_url="${base_url%/}/v1"
+          cat > "$HOME/.codex/config.toml" << EOF
           model_provider = "OpenAI"
           model = "${MODEL}"
-          disable_response_storage = true
-
-          [features]
-          multi_agent = true
-          multi_agent_v2 = true
-
-          [agents]
-          enabled = true
 
           [model_providers.OpenAI]
           name = "OpenAI"
@@ -189,89 +160,29 @@ jobs:
           wire_api = "responses"
           requires_openai_auth = true
           EOF
-            if [ -n "$OPENAI_API_KEY" ]; then
-              cat > "$HOME/.codex/auth.json" << EOF
+          if [ -n "$OPENAI_API_KEY" ]; then
+            cat > "$HOME/.codex/auth.json" << EOF
           {"auth_mode":"apikey","OPENAI_API_KEY":"${OPENAI_API_KEY}"}
           EOF
-            fi
-          }
-
-          configure_codex
+          fi
           codex --version
-          codex features list --enable multi_agent --enable multi_agent_v2 | \
-            grep -E '^multi_agent(_v2)?[[:space:]]+stable[[:space:]]+true$'
+          source /tmp/agora-credentials.env
+          python3 scripts/run_codex_eval.py
 
-          preflight_marker="/tmp/codex-subagent-preflight.marker"
-          preflight_output="/tmp/codex-subagent-preflight.md"
-          preflight_child_marker="/tmp/codex-subagent-preflight-child.marker"
-          : > "$preflight_marker"
-          : > "$preflight_output"
-          : > "$preflight_child_marker"
-          cat > /tmp/codex-subagent-preflight.txt << 'HEREDOC'
-          Use spawn_agent with fork_context: false to start one fresh child agent.
-          Ask the child to overwrite /tmp/codex-subagent-preflight-child.marker with exactly: SUBAGENT_CHILD_EXECUTED
-          Then ask the child to reply exactly: SUBAGENT_PREFLIGHT_OK
-          Wait for the child to finish, then reply exactly: SUBAGENT_PREFLIGHT_OK
-          HEREDOC
-          codex exec --enable multi_agent --enable multi_agent_v2 \
-            --skip-git-repo-check --sandbox danger-full-access \
-            --output-last-message "$preflight_output" < /tmp/codex-subagent-preflight.txt
-          grep -qx 'SUBAGENT_PREFLIGHT_OK' "$preflight_output"
-          grep -qx 'SUBAGENT_CHILD_EXECUTED' "$preflight_child_marker"
-          find "$HOME/.codex/sessions" -type f -name '*.jsonl' -newer "$preflight_marker" \
-            -exec grep -l 'subagent' {} + | grep -q .
-
-          run_codex_once() {
-            local attempt="$1"
-            local log_file="$2"
-            local output_file="$3"
-            codex exec --enable multi_agent --enable multi_agent_v2 \
-              --skip-git-repo-check --sandbox danger-full-access \
-              --output-last-message "${output_file}" < /tmp/eval-prompt.txt \
-              > "${log_file}" 2>&1
-          }
-
-          attempt=1
-          first_rc=0
-          run_codex_once 1 "/tmp/codex-run-attempt-1.log" "/tmp/codex-eval-output.md" || first_rc=$?
-
-          if [ "$first_rc" -ne 0 ] && \
-            grep -E "stream disconnected|stream closed before response\\.completed" \
-            "/tmp/codex-run-attempt-1.log" >/dev/null 2>&1; then
-            echo "Detected stream-disconnect on attempt 1, retrying once."
-            attempt=2
-            second_rc=0
-            run_codex_once 2 "/tmp/codex-run-attempt-2.log" "/tmp/codex-eval-output.md" || second_rc=$?
-            final_rc="$second_rc"
-          else
-            final_rc="$first_rc"
-          fi
-
-          if [ "${final_rc}" -ne 0 ]; then
-            echo "::error::Codex evaluator failed (response stream disconnect or endpoint issue). Re-run workflow or check RESPONSES_API_ENDPOINT."
-            if [ "$attempt" -eq 1 ]; then
-              cat /tmp/codex-run-attempt-1.log
-            else
-              cat /tmp/codex-run-attempt-2.log
-            fi
-            exit 1
-          fi
-
-          mkdir -p agentic-evals
-          cp /tmp/codex-eval-output.md agentic-evals/codex-final-message.md
+      - name: Generate report
+        if: always() && steps.resolve.outputs.run_dir != ''
+        working-directory: agentic-evals
+        env:
+          RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
+        run: python3 scripts/generate_report.py
 
       - name: Locate run artifacts
         id: artifacts
         run: |
-          LATEST_RUN=$(ls -td agentic-evals/runs/*/ 2>/dev/null | head -1)
-          if [ -z "$LATEST_RUN" ]; then
-            echo "::warning::No run directory found"
-            echo "run_found=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "run_dir=${LATEST_RUN}" >> "$GITHUB_OUTPUT"
+          RUN_DIR="agentic-evals/${{ steps.resolve.outputs.run_dir }}"
+          echo "run_dir=${RUN_DIR}" >> "$GITHUB_OUTPUT"
           echo "run_found=true" >> "$GITHUB_OUTPUT"
-          [ -f "${LATEST_RUN}/report.md" ] \
+          [ -f "${RUN_DIR}/report.md" ] \
             && echo "report_exists=true" >> "$GITHUB_OUTPUT" \
             || echo "report_exists=false" >> "$GITHUB_OUTPUT"
 
@@ -323,7 +234,7 @@ jobs:
           BLOCKED=$(grep -rl '"status": "blocked"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
           echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
           if [ "$FAIL" -gt 0 ] || [ "$BLOCKED" -gt 0 ]; then
-            echo "::error::${FAIL} fail, ${BLOCKED} blocked — see report for details"
+            echo "::error::${FAIL} fail, ${BLOCKED} blocked - see report for details"
             exit 1
           fi
 

--- a/.github/workflows/gemini-eval.yml
+++ b/.github/workflows/gemini-eval.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Setup eval harness
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
+          eval_repo: littleDogWang/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Setup Python
@@ -113,7 +114,9 @@ jobs:
         working-directory: agentic-evals
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GOOGLE_GEMINI_BASE_URL: ${{ secrets.GOOGLE_GEMINI_BASE_URL }}
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
+          # The latest Gemini CLI rejects Gateway auth before making a request.
+          # Without GOOGLE_GEMINI_BASE_URL it uses the supported Gemini API path.
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}

--- a/.github/workflows/gemini-eval.yml
+++ b/.github/workflows/gemini-eval.yml
@@ -44,6 +44,7 @@ jobs:
           path: skills-repo
 
       - name: Setup eval harness
+        id: setup
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
           eval_repo: littleDogWang/agentic-evals
@@ -126,14 +127,14 @@ jobs:
           python3 scripts/run_gemini_eval.py
 
       - name: Generate report
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         working-directory: agentic-evals
         env:
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
         run: python3 scripts/generate_report.py
 
       - name: Upload artifacts
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         uses: actions/upload-artifact@v4
         with:
           name: eval-run-gemini-${{ env.TARGET_ID }}-${{ github.run_id }}
@@ -142,7 +143,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Post report to job summary
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
         run: |
@@ -153,7 +154,7 @@ jobs:
           fi
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && always() && steps.resolve.outputs.run_dir != ''
         uses: actions/github-script@v7
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
@@ -173,15 +174,27 @@ jobs:
             });
 
       - name: Report results
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
         run: |
           RESULTS_DIR="${RUN_DIR}/case-results"
           [ -d "$RESULTS_DIR" ] || { echo "::warning::No case-results"; exit 0; }
-          FAIL=$(grep -rl '"status": "fail"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
-          PASS=$(grep -rl '"status": "pass"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
-          BLOCKED=$(grep -rl '"status": "blocked"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
+          read -r PASS FAIL BLOCKED < <(python3 - "$RESULTS_DIR" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          counts = {"pass": 0, "fail": 0, "blocked": 0}
+          for path in Path(sys.argv[1]).glob("*.json"):
+              try:
+                  status = json.loads(path.read_text()).get("status")
+              except (OSError, json.JSONDecodeError):
+                  status = "blocked"
+              counts[status if status in counts else "blocked"] += 1
+          print(counts["pass"], counts["fail"], counts["blocked"])
+          PY
+          )
           echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
           if [ "$FAIL" -gt 0 ] || [ "$BLOCKED" -gt 0 ]; then
             echo "::error::${FAIL} fail, ${BLOCKED} blocked — see report for details"
@@ -189,7 +202,7 @@ jobs:
           fi
 
       - name: Notify Feishu
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.resolve.outputs.run_dir != ''
         env:
           FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
           FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}

--- a/.github/workflows/gemini-eval.yml
+++ b/.github/workflows/gemini-eval.yml
@@ -30,6 +30,8 @@ env:
 
 jobs:
   evaluate:
+    # Temporarily disabled - confirm re-enable criteria before flipping back.
+    if: ${{ false }}
     runs-on: macos-latest
     timeout-minutes: 90
     permissions:
@@ -47,7 +49,7 @@ jobs:
         id: setup
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          eval_repo: littleDogWang/agentic-evals
+          eval_repo: AgoraIO/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Setup Python
@@ -197,7 +199,7 @@ jobs:
           )
           echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
           if [ "$FAIL" -gt 0 ] || [ "$BLOCKED" -gt 0 ]; then
-            echo "::error::${FAIL} fail, ${BLOCKED} blocked — see report for details"
+            echo "::error::${FAIL} fail, ${BLOCKED} blocked - see report for details"
             exit 1
           fi
 

--- a/.github/workflows/hermes-eval.yml
+++ b/.github/workflows/hermes-eval.yml
@@ -12,7 +12,7 @@ on:
         required: false
         default: "convoai-e2e-first-success"
       hermes_model:
-        description: "Hermes model (e.g. openai/gpt-4o)"
+        description: "Hermes model (e.g. gpt-5.4)"
         required: false
         default: ""
       eval_ref:
@@ -48,7 +48,9 @@ jobs:
       - name: Setup eval harness
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          eval_ref: ${{ github.event.inputs.eval_ref || '' }}
+          # Temporary fork pin for validating expanded Hermes runtime diagnostics.
+          eval_repo: littleDogWang/agentic-evals
+          eval_ref: ${{ github.event.inputs.eval_ref || 'fd1a5ae10ddbb53cc55e311079ca108ee23d36d4' }}
 
       - name: Validate YAML
         working-directory: agentic-evals
@@ -78,7 +80,11 @@ jobs:
       - name: Install runtime dependencies
         run: |
           pip install pyyaml
-          npm install -g agent-browser @openai/codex
+          npm install -g --allow-scripts=agent-browser agent-browser @openai/codex
+          agent-browser install
+          agent-browser --version
+          agent-browser --session hermes-preflight open about:blank
+          agent-browser --session hermes-preflight close
 
       - name: Install Hermes Agent
         run: |
@@ -89,8 +95,8 @@ jobs:
 
       - name: Configure Hermes
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
           HERMES_MODEL: ${{ github.event.inputs.hermes_model || '' }}
         run: |
           if [ -z "$OPENAI_API_KEY" ]; then
@@ -109,12 +115,17 @@ jobs:
           BASE_URL="${BASE_URL%/}/v1"
 
           # Determine model
-          MODEL="${HERMES_MODEL:-openai/gpt-4o}"
+          MODEL="${HERMES_MODEL:-gpt-5.4}"
 
-          # Configure via hermes config set (proven working approach)
-          hermes config set model.provider custom
-          hermes config set model.base_url "${BASE_URL}"
-          hermes config set model.model "${MODEL}"
+          # Use a named custom provider so Hermes sends the API key to the
+          # non-OpenAI endpoint and uses the Responses API transport.
+          hermes config set providers.test-endpoint.name test-endpoint
+          hermes config set providers.test-endpoint.base_url "${BASE_URL}"
+          hermes config set providers.test-endpoint.key_env OPENAI_API_KEY
+          hermes config set providers.test-endpoint.transport codex_responses
+          hermes config set providers.test-endpoint.default_model "${MODEL}"
+          hermes config set model.provider custom:test-endpoint
+          hermes config set model.default "${MODEL}"
           hermes config set agent.max_turns 90
           hermes config set tools.profile coding
           hermes config set terminal.backend local
@@ -122,11 +133,11 @@ jobs:
           # Write .env for API key
           echo "OPENAI_API_KEY=${OPENAI_API_KEY}" > ~/.hermes/.env
 
-          echo "Hermes configured: provider=custom, base_url=${BASE_URL}, model=${MODEL}"
+          echo "Hermes configured: provider=custom:test-endpoint, base_url=${BASE_URL}, model=${MODEL}"
 
       - name: Hermes auth smoke test
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
         run: |
           set -e
           if hermes run --max-turns 1 "Reply OK" >/tmp/hermes-smoke.log 2>&1; then
@@ -197,12 +208,13 @@ jobs:
       - name: Run two-phase evaluation
         working-directory: agentic-evals
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
           HERMES_MODEL: ${{ github.event.inputs.hermes_model || '' }}
+          AGENT_BROWSER_DEBUG: "1"
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           source /tmp/agora-credentials.env

--- a/.github/workflows/hermes-eval.yml
+++ b/.github/workflows/hermes-eval.yml
@@ -46,11 +46,11 @@ jobs:
           path: skills-repo
 
       - name: Setup eval harness
+        id: setup
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          # Temporary fork pin for validating expanded Hermes runtime diagnostics.
           eval_repo: littleDogWang/agentic-evals
-          eval_ref: ${{ github.event.inputs.eval_ref || 'fd1a5ae10ddbb53cc55e311079ca108ee23d36d4' }}
+          eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Validate YAML
         working-directory: agentic-evals
@@ -221,14 +221,14 @@ jobs:
           python3 scripts/run_hermes_eval.py
 
       - name: Generate report
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         working-directory: agentic-evals
         env:
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
         run: python3 scripts/generate_report.py
 
       - name: Upload run artifacts
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         uses: actions/upload-artifact@v4
         with:
           name: eval-run-hermes-${{ env.TARGET_ID }}-${{ github.run_id }}
@@ -237,7 +237,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Post report to job summary
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
         run: |
@@ -248,7 +248,7 @@ jobs:
           fi
 
       - name: Post report as PR comment
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && always() && steps.resolve.outputs.run_dir != ''
         uses: actions/github-script@v7
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
@@ -268,15 +268,27 @@ jobs:
             });
 
       - name: Report results
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
         run: |
           RESULTS_DIR="${RUN_DIR}/case-results"
           [ -d "$RESULTS_DIR" ] || { echo "::warning::No case-results"; exit 0; }
-          FAIL=$(grep -rl '"status": "fail"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
-          PASS=$(grep -rl '"status": "pass"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
-          BLOCKED=$(grep -rl '"status": "blocked"' "$RESULTS_DIR" 2>/dev/null | wc -l || echo 0)
+          read -r PASS FAIL BLOCKED < <(python3 - "$RESULTS_DIR" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          counts = {"pass": 0, "fail": 0, "blocked": 0}
+          for path in Path(sys.argv[1]).glob("*.json"):
+              try:
+                  status = json.loads(path.read_text()).get("status")
+              except (OSError, json.JSONDecodeError):
+                  status = "blocked"
+              counts[status if status in counts else "blocked"] += 1
+          print(counts["pass"], counts["fail"], counts["blocked"])
+          PY
+          )
           echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
           if [ "$FAIL" -gt 0 ] || [ "$BLOCKED" -gt 0 ]; then
             echo "::error::${FAIL} fail, ${BLOCKED} blocked — see report for details"
@@ -284,7 +296,7 @@ jobs:
           fi
 
       - name: Notify Feishu
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.resolve.outputs.run_dir != ''
         env:
           FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
           FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}

--- a/.github/workflows/hermes-eval.yml
+++ b/.github/workflows/hermes-eval.yml
@@ -49,7 +49,7 @@ jobs:
         id: setup
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          eval_repo: littleDogWang/agentic-evals
+          eval_repo: AgoraIO/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Validate YAML
@@ -91,12 +91,12 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup
           source ~/.bashrc || source ~/.zshrc || true
           export PATH="$HOME/.local/bin:$PATH"
-          hermes version
+          hermes --version
 
       - name: Configure Hermes
         env:
-          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
           HERMES_MODEL: ${{ github.event.inputs.hermes_model || '' }}
         run: |
           if [ -z "$OPENAI_API_KEY" ]; then
@@ -137,20 +137,39 @@ jobs:
 
       - name: Hermes auth smoke test
         env:
-          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -e
-          if hermes run --max-turns 1 "Reply OK" >/tmp/hermes-smoke.log 2>&1; then
-            echo "Hermes smoke test passed via hermes run."
-          elif hermes chat --yolo --quiet -q "Reply OK" >/tmp/hermes-smoke.log 2>&1; then
-            echo "Hermes smoke test passed via hermes chat."
-          else
-            echo "::error::Hermes auth smoke test failed. Confirm RESPONSES_API_ENDPOINT and OPENAI_API_KEY are valid."
-            cat /tmp/hermes-smoke.log
-            exit 1
-          fi
-          if grep -q "INVALID_API_KEY" /tmp/hermes-smoke.log; then
-            echo "::error::Hermes returned INVALID_API_KEY during smoke test."
+          smoke_passed=0
+          for attempt in 1 2 3; do
+            if hermes run --max-turns 1 "Reply OK" >/tmp/hermes-smoke.log 2>&1; then
+              echo "Hermes smoke test passed via hermes run."
+              smoke_passed=1
+              break
+            elif hermes chat --yolo --quiet -q "Reply OK" >/tmp/hermes-smoke.log 2>&1; then
+              echo "Hermes smoke test passed via hermes chat."
+              smoke_passed=1
+              break
+            fi
+
+            if grep -q "INVALID_API_KEY" /tmp/hermes-smoke.log; then
+              echo "::error::Hermes returned INVALID_API_KEY during smoke test."
+              cat /tmp/hermes-smoke.log
+              exit 1
+            fi
+            if ! grep -q "HTTP 503" /tmp/hermes-smoke.log; then
+              echo "::error::Hermes auth smoke test failed. Confirm RESPONSES_API_ENDPOINT and OPENAI_API_KEY are valid."
+              cat /tmp/hermes-smoke.log
+              exit 1
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::Hermes provider returned HTTP 503; retrying smoke test (${attempt}/3)."
+              sleep 15
+            fi
+          done
+
+          if [ "$smoke_passed" -ne 1 ]; then
+            echo "::error::Hermes provider remained unavailable after 3 smoke-test attempts."
             cat /tmp/hermes-smoke.log
             exit 1
           fi
@@ -208,8 +227,8 @@ jobs:
       - name: Run two-phase evaluation
         working-directory: agentic-evals
         env:
-          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
@@ -274,7 +293,7 @@ jobs:
         run: |
           RESULTS_DIR="${RUN_DIR}/case-results"
           [ -d "$RESULTS_DIR" ] || { echo "::warning::No case-results"; exit 0; }
-          read -r PASS FAIL BLOCKED < <(python3 - "$RESULTS_DIR" <<'PY'
+          COUNTS=$(python3 -c '
           import json
           import sys
           from pathlib import Path
@@ -287,11 +306,11 @@ jobs:
                   status = "blocked"
               counts[status if status in counts else "blocked"] += 1
           print(counts["pass"], counts["fail"], counts["blocked"])
-          PY
-          )
+          ' "$RESULTS_DIR")
+          read -r PASS FAIL BLOCKED <<< "$COUNTS"
           echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
           if [ "$FAIL" -gt 0 ] || [ "$BLOCKED" -gt 0 ]; then
-            echo "::error::${FAIL} fail, ${BLOCKED} blocked — see report for details"
+            echo "::error::${FAIL} fail, ${BLOCKED} blocked - see report for details"
             exit 1
           fi
 

--- a/.github/workflows/openclaw-eval.yml
+++ b/.github/workflows/openclaw-eval.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Setup eval harness
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          eval_ref: ${{ github.event.inputs.eval_ref || '' }}
+          eval_repo: littleDogWang/agentic-evals
+          eval_ref: fd1a5ae10ddbb53cc55e311079ca108ee23d36d4
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -67,8 +68,8 @@ jobs:
 
       - name: Configure OpenClaw
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
         run: |
           mkdir -p ~/.openclaw/agents/main/sessions
           GATEWAY_TOKEN=$(openssl rand -hex 24)
@@ -189,8 +190,8 @@ jobs:
       - name: Run two-phase evaluation
         working-directory: agentic-evals
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}

--- a/.github/workflows/openclaw-eval.yml
+++ b/.github/workflows/openclaw-eval.yml
@@ -51,7 +51,7 @@ jobs:
         id: setup
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          eval_repo: littleDogWang/agentic-evals
+          eval_repo: AgoraIO/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Setup Python
@@ -62,15 +62,15 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pyyaml
-          npm install -g acpx@latest agent-browser @openai/codex
+          npm install -g acpx@0.13.0 agent-browser @openai/codex
           npm install -g openclaw@latest
           openclaw --version
           acpx --version
 
       - name: Configure OpenClaw
         env:
-          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
         run: |
           mkdir -p ~/.openclaw/agents/main/sessions
           GATEWAY_TOKEN=$(openssl rand -hex 24)
@@ -191,8 +191,8 @@ jobs:
       - name: Run two-phase evaluation
         working-directory: agentic-evals
         env:
-          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
           AGORA_APP_CERTIFICATE: ${{ secrets.AGORA_APP_CERTIFICATE }}
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
@@ -271,7 +271,7 @@ jobs:
           )
           echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
           if [ "$FAIL" -gt 0 ] || [ "$BLOCKED" -gt 0 ]; then
-            echo "::error::${FAIL} fail, ${BLOCKED} blocked — see report for details"
+            echo "::error::${FAIL} fail, ${BLOCKED} blocked - see report for details"
             exit 1
           fi
 

--- a/.github/workflows/openclaw-eval.yml
+++ b/.github/workflows/openclaw-eval.yml
@@ -48,10 +48,11 @@ jobs:
         run: corepack enable && corepack prepare pnpm@latest --activate
 
       - name: Setup eval harness
+        id: setup
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
           eval_repo: littleDogWang/agentic-evals
-          eval_ref: fd1a5ae10ddbb53cc55e311079ca108ee23d36d4
+          eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -200,14 +201,14 @@ jobs:
           python3 scripts/run_openclaw_eval.py
 
       - name: Generate report
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         working-directory: agentic-evals
         env:
           RUN_DIR: ${{ steps.resolve.outputs.run_dir }}
         run: python3 scripts/generate_report.py
 
       - name: Upload artifacts
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         uses: actions/upload-artifact@v4
         with:
           name: eval-run-openclaw-${{ env.TARGET_ID }}-${{ github.run_id }}
@@ -216,7 +217,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Post report to job summary
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
         run: |
@@ -227,7 +228,7 @@ jobs:
           fi
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && always() && steps.resolve.outputs.run_dir != ''
         uses: actions/github-script@v7
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
@@ -247,15 +248,27 @@ jobs:
             });
 
       - name: Report results
-        if: always()
+        if: always() && steps.resolve.outputs.run_dir != ''
         env:
           RUN_DIR: agentic-evals/${{ steps.resolve.outputs.run_dir }}
         run: |
           RESULTS_DIR="${RUN_DIR}/case-results"
           [ -d "$RESULTS_DIR" ] || { echo "::warning::No case-results"; exit 0; }
-          FAIL=$(grep -rl '"status": "fail"' "$RESULTS_DIR" 2>/dev/null | wc -l | tr -d ' ')
-          PASS=$(grep -rl '"status": "pass"' "$RESULTS_DIR" 2>/dev/null | wc -l | tr -d ' ')
-          BLOCKED=$(grep -rl '"status": "blocked"' "$RESULTS_DIR" 2>/dev/null | wc -l | tr -d ' ')
+          read -r PASS FAIL BLOCKED < <(python3 - "$RESULTS_DIR" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          counts = {"pass": 0, "fail": 0, "blocked": 0}
+          for path in Path(sys.argv[1]).glob("*.json"):
+              try:
+                  status = json.loads(path.read_text()).get("status")
+              except (OSError, json.JSONDecodeError):
+                  status = "blocked"
+              counts[status if status in counts else "blocked"] += 1
+          print(counts["pass"], counts["fail"], counts["blocked"])
+          PY
+          )
           echo "Results: ${PASS} pass, ${FAIL} fail, ${BLOCKED} blocked"
           if [ "$FAIL" -gt 0 ] || [ "$BLOCKED" -gt 0 ]; then
             echo "::error::${FAIL} fail, ${BLOCKED} blocked — see report for details"
@@ -263,7 +276,7 @@ jobs:
           fi
 
       - name: Notify Feishu
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.resolve.outputs.run_dir != ''
         env:
           FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
           FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}

--- a/.github/workflows/skill-judge.yml
+++ b/.github/workflows/skill-judge.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Setup eval harness
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
+          eval_repo: littleDogWang/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Install Codex CLI
@@ -75,8 +76,8 @@ jobs:
       - name: Run Codex judge with stream-safe retry
         id: run_judge
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
           MODEL: gpt-5.4
         run: |
           set -e

--- a/.github/workflows/skill-judge.yml
+++ b/.github/workflows/skill-judge.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup eval harness
         uses: ./skills-repo/.github/actions/setup-eval-harness
         with:
-          eval_repo: littleDogWang/agentic-evals
+          eval_repo: AgoraIO/agentic-evals
           eval_ref: ${{ github.event.inputs.eval_ref || '' }}
 
       - name: Install Codex CLI
@@ -76,8 +76,8 @@ jobs:
       - name: Run Codex judge with stream-safe retry
         id: run_judge
         env:
-          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
-          RESPONSES_API_ENDPOINT: ${{ secrets.TEST_RESPONSES_API_ENDPOINT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          RESPONSES_API_ENDPOINT: ${{ secrets.RESPONSES_API_ENDPOINT }}
           MODEL: gpt-5.4
         run: |
           set -e

--- a/.github/workflows/sync-anthropics-fork.yml
+++ b/.github/workflows/sync-anthropics-fork.yml
@@ -26,7 +26,8 @@ permissions:
 
 jobs:
   sync:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Temporarily disabled until the fork sync destination is re-approved.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     env:
       TARGET_REPO: AgoraIO/skills

--- a/skills/agora/references/conversational-ai/quickstarts.md
+++ b/skills/agora/references/conversational-ai/quickstarts.md
@@ -210,11 +210,11 @@ Exit code alone does not determine whether to proceed. Read command output and m
 
 ### Node/TS baseline (`agent-quickstart-nextjs`)
 
-After `pnpm install`:
+After `pnpm install` reports `[ERR_PNPM_IGNORED_BUILDS]`:
 
-- **`[ERR_PNPM_IGNORED_BUILDS]`** is not a blocking error. The sample's dev script uses `next dev --webpack` explicitly — esbuild, sharp, and unrs-resolver build scripts are not required for the dev path. If packages were added and the only non-zero exit is this warning, proceed directly to `pnpm dev`.
-- If `pnpm dev` re-runs an install check and prints the same ignored-builds warning, treat that as non-blocking too — run the README `pnpm dev` again or start the documented dev script from the quickstart directory. Do not stop before a dev server is listening.
-- Do not run `pnpm approve-builds`, `pnpm config set onlyBuiltDependencies`, `pnpm dev --ignore-scripts`, edit `package.json` with pnpm config fields, create `pnpm.yaml`, or change global pnpm build-approval settings to resolve this warning during first-success setup.
+- Run the documented `pnpm dev` once. The warning is non-blocking only if that command starts Next.js and a real GET of the local URL returns a non-empty successful response.
+- If `pnpm dev` exits before Next.js starts with the same ignored-builds error, use the sample's npm scripts without changing the quickstart's tracked configuration: `npm install --package-lock=false`, then `npm run dev`. This installs the required dependency scripts but does not create `package-lock.json`, `pnpm-workspace.yaml`, or `pnpm.yaml`.
+- Do not run `pnpm approve-builds`, set pnpm build-approval configuration, add pnpm configuration to `package.json`, or create `pnpm-workspace.yaml` / `pnpm.yaml`.
 
 ## Command Integrity Under Environment Restrictions
 
@@ -250,10 +250,7 @@ Do **not** reinterpret these failures as sample misconfiguration and do **not** 
 
 ### Install warnings (Node/TS baseline)
 
-When `pnpm install` exits non-zero:
-
-- If the output is caused solely by `[ERR_PNPM_IGNORED_BUILDS]`, classify it as a **warning**, not a failure. Continue to the next documented command (`pnpm dev`). Do not attempt to resolve it before starting the app.
-- Do not treat this warning as sample misconfiguration or as proof that dependencies failed to install.
+When `pnpm install` exits non-zero only for `[ERR_PNPM_IGNORED_BUILDS]`, packages may still be linked but required lifecycle scripts have not run. Start with `pnpm dev` and verify the page with a real GET. If that command exits before Next.js starts for the same reason, use the npm fallback in [Known Non-Blocking Warnings](#known-non-blocking-warnings). Do not describe the sample as ready until the page is actually reachable.
 
 ## First-Success Readiness Layers
 
@@ -553,7 +550,7 @@ Run these commands in order. Use `--json` where available so you can parse the o
 
 7. **Sample-ready gate**
    - Install dependencies and start the official sample using the documented commands.
-   - If `pnpm install` exits non-zero with only `[ERR_PNPM_IGNORED_BUILDS]`, treat install as complete and continue to `pnpm dev` — see [Known Non-Blocking Warnings](#known-non-blocking-warnings).
+   - If `pnpm install` exits non-zero with only `[ERR_PNPM_IGNORED_BUILDS]`, try `pnpm dev` once. If it exits before Next.js starts for the same reason, use the no-lockfile npm fallback in [Known Non-Blocking Warnings](#known-non-blocking-warnings).
    - The quickstart is only fully ready when the app opens, the user can press `Try it now`, the agent joins, and the frontend stays up.
    - If a failure is localized to the official sample itself rather than the environment or project readiness, a minimal upstream-shaped workaround is allowed. Do not replace the sample with a self-built implementation.
 

--- a/tests/eval-cases.md
+++ b/tests/eval-cases.md
@@ -487,18 +487,18 @@ For each case:
 - Pass Criteria: Preserves the sample architecture, env names, token flow, lifecycle, and documented commands; does not self-build a replacement app
 - Result: ___
 
-### I-41: ERR_PNPM_IGNORED_BUILDS is non-blocking during Node/TS install
+### I-41: ERR_PNPM_IGNORED_BUILDS falls back without changing the quickstart
 
 - User Input: "`pnpm install` finished adding packages but exited 1 with `[ERR_PNPM_IGNORED_BUILDS]` for esbuild, sharp, and unrs-resolver. What next?"
-- Expected Behavior: Classifies the warning as non-blocking and continues to the documented start command
-- Pass Criteria: Proceeds to `pnpm dev`; does not run `pnpm approve-builds`, edit `package.json`/`pnpm.yaml`, or change global pnpm build settings; cites that the sample dev script uses `next dev --webpack`
+- Expected Behavior: Runs `pnpm dev` once, then switches to the standard npm scripts only if pnpm prevents Next.js from starting with the same error
+- Pass Criteria: Uses `npm install --package-lock=false` followed by `npm run dev` when fallback is needed; does not run `pnpm approve-builds`, edit `package.json`, create `pnpm-workspace.yaml`/`pnpm.yaml`, or change global pnpm build settings; verifies the local page with a real GET
 - Result: ___
 
 ### I-42: Expand exported Agora credentials into quickstart env file
 
 - User Input: "AGORA_APP_ID and AGORA_APP_CERTIFICATE are already in my shell. Write the Node quickstart `.env.local` and start the dev server."
 - Expected Behavior: Writes `.env.local` with resolved `NEXT_PUBLIC_AGORA_APP_ID` and `NEXT_AGORA_APP_CERTIFICATE` values (not literal `$AGORA_APP_ID` placeholders), then runs the documented start command
-- Pass Criteria: Env file contains non-empty concrete values; does not leave shell-variable names as literal text in the file; proceeds to `pnpm dev` after install warnings per I-41
+- Pass Criteria: Env file contains non-empty concrete values; does not leave shell-variable names as literal text in the file; starts with `pnpm dev` and uses the I-41 npm fallback only if pnpm prevents Next.js from starting
 - Result: ___
 
 ### I-29: Recovery after custom-server deviation


### PR DESCRIPTION
## Summary

- stabilize Codex, Gemini, Hermes, and OpenClaw evaluator workflows
- make evaluator result reporting portable across runner environments
- pin evaluator dependencies and align the ConvoAI quickstart and eval cases with the workflow contract
- keep the Anthropic fork sync disabled

## Validation

- bash scripts/validate-skills.sh
- git diff --check main...HEAD